### PR TITLE
fix: generalize task code marker in prompt definitions

### DIFF
--- a/src/mcp/prompts/definitions/create-task.md
+++ b/src/mcp/prompts/definitions/create-task.md
@@ -70,7 +70,7 @@ Each task MUST be:
 ### 3. TASK ATTRIBUTES (MANDATORY)
 
 Each `@vheins/local-memory-mcp tools task-create` MUST include:
-* `task_code`: (FEAT-XXX / FIX-XXX / REFACTOR-XXX)
+* `task_code`: (e.g., FEAT-123 / FIX-456 / REFACTOR-789)
 * `phase`: (Discovery / Implementation / Testing)
 * `priority`: (1–5)
 * `agent`: Current agent's name/role

--- a/src/mcp/prompts/definitions/review-and-audit.md
+++ b/src/mcp/prompts/definitions/review-and-audit.md
@@ -75,7 +75,7 @@ Each task MUST be:
 
 ### 5. TASK ATTRIBUTES (MANDATORY)
 Each `@vheins/local-memory-mcp tools task-create` MUST include:
-* `task_code`: (FEAT-XXX / FIX-XXX / REFACTOR-XXX)
+* `task_code`: (e.g., FEAT-123 / FIX-456 / REFACTOR-789)
 * `phase`: (Discovery / Implementation / Testing)
 * `priority`: (1–5)
 * `agent`: Current agent's name/role


### PR DESCRIPTION
Generalize placeholder task code markers (e.g. FEAT-XXX) in the `create-task.md` and `review-and-audit.md` prompt templates to prevent them from triggering regex trackers that search for literal 'XXX' suffixes. Markers were replaced with `(e.g., FEAT-123 / FIX-456 / REFACTOR-789)`.

---
*PR created automatically by Jules for task [17838439277941290901](https://jules.google.com/task/17838439277941290901) started by @vheins*