### PR TITLE
⚡ Optimize N+1 Query in handleTaskUpdate

### DIFF
--- a/src/mcp/entities/task.ts
+++ b/src/mcp/entities/task.ts
@@ -78,6 +78,38 @@ export class TaskEntity extends BaseEntity {
 		return row ? { ...this.rowToTask(row), comments: this.getTaskCommentsByTaskId(id) } : null;
 	}
 
+	getTasksByIds(ids: string[]): Task[] {
+		if (ids.length === 0) return [];
+		const placeholders = ids.map(() => "?").join(",");
+		const rows = this.all<Record<string, unknown>>(
+			`SELECT t.*, d.task_code as depends_on_code,
+				(SELECT COUNT(*) FROM task_comments WHERE task_id = t.id) as comments_count
+			FROM tasks t
+			LEFT JOIN tasks d ON t.depends_on = d.id
+			WHERE t.id IN (${placeholders})`,
+			ids
+		);
+
+		const comments = this.all<TaskComment>(
+			`SELECT * FROM task_comments WHERE task_id IN (${placeholders}) ORDER BY created_at DESC, id DESC`,
+			ids
+		);
+
+		const commentsMap = new Map<string, TaskComment[]>();
+		for (const c of comments) {
+			if (!commentsMap.has(c.task_id)) {
+				commentsMap.set(c.task_id, []);
+			}
+			commentsMap.get(c.task_id)!.push(c);
+		}
+
+		return rows.map((r) => {
+			const task = this.rowToTask(r);
+			task.comments = commentsMap.get(task.id) || [];
+			return task;
+		});
+	}
+
 	getTaskByCode(repo: string, taskCode: string): Task | null {
 		const row = this.get<Record<string, unknown>>(
 			`SELECT t.*, d.task_code as depends_on_code FROM tasks t LEFT JOIN tasks d ON t.depends_on = d.id WHERE t.repo = ? AND t.task_code = ?`,

--- a/src/mcp/tools/task.manage.ts
+++ b/src/mcp/tools/task.manage.ts
@@ -529,8 +529,11 @@ export async function handleTaskUpdate(args: unknown, storage: SQLiteStore, vect
 	const now = new Date().toISOString();
 	const isStatusChangingGlobal = updates.status !== undefined;
 
+	const existingTasks = storage.tasks.getTasksByIds(targetIds);
+	const taskMap = new Map(existingTasks.map(t => [t.id, t]));
+
 	for (const targetId of targetIds) {
-		const existingTask = storage.tasks.getTaskById(targetId);
+		const existingTask = taskMap.get(targetId);
 		if (!existingTask) {
 			if (id) throw new Error(`Task not found: ${targetId}`);
 			continue;


### PR DESCRIPTION
This PR optimizes the `handleTaskUpdate` tool by addressing an N+1 query inefficiency.

### 💡 What
- Implemented a new `getTasksByIds(ids: string[])` method in the `TaskEntity` storage layer. This method uses a single `SELECT ... IN (...)` query to fetch task data and another bulk query to fetch comments for all requested tasks, ensuring parity with the single-fetch `getTaskById` method.
- Refactored `handleTaskUpdate` in `src/mcp/tools/task.manage.ts` to pre-fetch all tasks being updated before entering the processing loop.

### 🎯 Why
Previously, `handleTaskUpdate` would call `storage.tasks.getTaskById(targetId)` for every task ID provided in the `ids` array. For bulk updates involving many tasks, this resulted in many round-trips to the database (N+1 queries), which is inefficient for I/O and CPU.

### 📊 Measured Improvement
While environment constraints prevented running a full automated benchmark, the optimization reduces the number of database queries from `O(N)` (where N is the number of tasks being updated) to `O(1)` (two constant-time bulk queries). This provides a measurable efficiency gain for any bulk task update operation.

---
*PR created automatically by Jules for task [1223001797805788018](https://jules.google.com/task/1223001797805788018) started by @vheins*