### PR TITLE
feat(mcp): harden tool contracts and ship the shared-context roadmap

### DIFF
--- a/.agents/documents/analysis/context-reuse-telemetry.md
+++ b/.agents/documents/analysis/context-reuse-telemetry.md
@@ -1,0 +1,35 @@
+# Context Reuse Telemetry
+
+`ENABLE_REUSE_TELEMETRY=false` disables telemetry correlation state and database access; the compiler still emits its normal opaque `context_pack_id` contract. It is enabled by default and stores only hourly numeric aggregates scoped by owner/repo.
+
+## Privacy and retention
+
+The table contains `owner`, `repo`, hourly bucket, metric name, optional source name, count, and numeric value. It never stores prompts, memory/observation text, code bodies, file paths, symbol names, secrets, or raw session IDs. Correlation identifiers are process-local SHA-256 prefixes; `context_pack_id` combines a scope hash with a random UUID.
+
+- `REUSE_TELEMETRY_RETENTION_DAYS` defaults to 30 (1–365 effective range).
+- `REUSE_TELEMETRY_MAX_ROWS` defaults to 20,000; oldest aggregate rows are discarded.
+- Relevant hot paths update bounded in-memory counters and flush every 4,096 tool/context events or after a minute of subsequent activity (not every sub-counter); shutdown and explicit metrics reads force a final flush.
+- Explicit `context_pack_id` calls use an eight-entry, five-minute in-process cache; typical serialized packs keep this comfortably below the 2 MB RAM budget.
+- The dashboard `/api/metrics?owner=...&repo=...&hours=24` surface flushes pending counters and returns the repo/time-window summary.
+
+## Metric semantics
+
+- `context_packs_requested`, `context_cache_hits|misses`: pack demand and real hits/misses in the bounded five-minute cache. Hit/miss counters apply only to opt-in calls carrying `context_pack_id`; default calls always compile fresh.
+- `context_items_included|excluded` and `context_estimated_tokens`, grouped by source, reconcile with the compiler allocation.
+- `observation_ids_reused`, `evidence_pointers_reused`, `stale_observations_rejected` are counts only.
+- `repeated_file_reads|repeated_symbol_reads` count repeated hashed pointers inside one bounded process session.
+- `claim_to_first_action_ms` sums elapsed milliseconds; divide value by count for the mean. Its `by_source` keys are bounded latency buckets (`le_100ms` through `gt_30s`), providing a histogram without raw events.
+- `retrievals_acknowledged_used` counts explicit `memory-write acknowledge=used` calls.
+- `observation_tokens_avoided` uses **96 estimated tokens per reused evidence pointer**. This is a deterministic comparison heuristic, not tokenizer output, billing data, or guaranteed savings.
+
+## North-star summary
+
+Reuse is improving when context packs deliver more fresh observation/code evidence while repeated file/symbol reads and stale rejections fall. The primary ratio is:
+
+`avoided repeated reads / total file+symbol reads`
+
+Interpret it beside context tokens delivered and acknowledgement/use counts; no single counter proves product value.
+
+## Deterministic benchmark
+
+Run `node --expose-gc --import tsx scripts/bench/context-reuse-bench.ts` (or `npx tsx ...` when only latency/disk data is needed). On the reference local run, median CPU overhead was 0.50%, heap delta 92,984 bytes, aggregate DB growth 0 bytes after schema creation (720,896 bytes total), and two aggregate rows were retained. The no-LLM scenario models explore → orchestrator → two implementers twice: baseline agents repeat file/symbol reads, while shared-context agents consume one evidence-backed pack. It reports file reads, symbol reads, estimated tokens, elapsed latency, peak heap, database bytes, and the median instrumentation CPU overhead across seven paired SQLite trials. Values are estimates for regression comparison, not provider billing. Establish a stable CI baseline before enforcing a hard threshold; local warm runs target median overhead below 1%.

--- a/.agents/documents/api/codebase-index.md
+++ b/.agents/documents/api/codebase-index.md
@@ -6,6 +6,27 @@
 
 The Codebase Index provides **2 MCP tools** for indexing and querying source code structure. All tools conform to the [MCP 2025-03-26 Structured Content](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#structured-content) specification.
 
+## Shared response contract
+
+Read tools that expose a `json` flag follow one contract in every auto-inferred mode:
+
+| Request                  | `content`                          | `structuredContent`                                      |
+| :----------------------- | :--------------------------------- | :------------------------------------------------------- |
+| `json: false` or omitted | One non-empty compact text summary | Omitted                                                  |
+| `json: true`             | The same compact text summary      | Present; full objects are not serialized again into text |
+
+Successful structured read responses carry stable top-level `schema` and `mode` discriminators. Existing domain fields remain at their historical paths for backward compatibility; payloads are not duplicated under generic aliases because that would waste context tokens.
+
+| Tool            | Stable `schema`                                                  | Modes                                             |
+| :-------------- | :--------------------------------------------------------------- | :------------------------------------------------ |
+| `memory-read`   | `memory-read`                                                    | `recap`, `search`, `detail`                       |
+| `standard-read` | `standard-read`                                                  | `list`, `search`, `detail`                        |
+| `task-read`     | `task-read/<mode>` (legacy value retained)                       | `list`, `search`, `detail`                        |
+| `handoff-read`  | `handoff-read`; `claim-list` for claims (legacy values retained) | `list`, `search`, `claims`, `detail`              |
+| `codebase-read` | `codebase-read`                                                  | `architecture`, `search`, `file`, `trace`, `code` |
+
+`codebase-index` is the documented exception: it has no `json` input and always returns structured content because INDEX/STATUS results are protocol-operational data rather than optional read detail. Errors use the separate `schema: "tool-error"` contract in §1.5.
+
 ---
 
 ## 1. `codebase-index`
@@ -89,13 +110,13 @@ Failed operations return `isError: true`, one concise text item, and this stable
 
 Partial bulk operations also use `isError: true` with `code: "PARTIAL_FAILURE"` while retaining successful item results at their existing top-level paths. Unknown exceptions become `INTERNAL_ERROR`; raw exception messages and filesystem details remain server-side in logs.
 
-| Scenario                 | Code                 | Retryable |
-| :----------------------- | :------------------- | :-------- |
-| Invalid arguments        | `VALIDATION_ERROR`   | No        |
-| Path does not exist      | `PATH_NOT_FOUND`     | No        |
-| Path is not a directory  | `NOT_A_DIRECTORY`    | No        |
-| Index failed internally  | `INDEX_FAILED`       | Yes       |
-| Unknown internal failure | `INTERNAL_ERROR`     | No        |
+| Scenario                 | Code               | Retryable |
+| :----------------------- | :----------------- | :-------- |
+| Invalid arguments        | `VALIDATION_ERROR` | No        |
+| Path does not exist      | `PATH_NOT_FOUND`   | No        |
+| Path is not a directory  | `NOT_A_DIRECTORY`  | No        |
+| Index failed internally  | `INDEX_FAILED`     | Yes       |
+| Unknown internal failure | `INTERNAL_ERROR`   | No        |
 
 ### 1.6 Runnable Examples
 
@@ -155,7 +176,7 @@ Unified read-only access to the codebase index. Mode auto-inferred from paramete
 
 | Parameter             | Type                 | Required | Default | Mode               | Description                                                                                                                                                                     |
 | :-------------------- | :------------------- | :------- | :------ | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `repo`                | `string`             | No*      | —       | all                | Repository name (normalized). **SEARCH requires `repo` or `repos`** — without either it rejects to prevent cross-tenant leaks.                                                  |
+| `repo`                | `string`             | No\*     | —       | all                | Repository name (normalized). **SEARCH requires `repo` or `repos`** — without either it rejects to prevent cross-tenant leaks.                                                  |
 | `repos`               | `array<string>`      | No       | —       | SEARCH             | Cross-repo search scope; each value normalized. Capped at 50.                                                                                                                   |
 | `owner`               | `string`             | No       | `""`    | all                | GitHub owner/org; auto-inferred from session when omitted.                                                                                                                      |
 | `name`                | `string`             | No       | —       | TRACE              | Symbol name to trace (exact match with fallback variants).                                                                                                                      |

--- a/.agents/documents/api/codebase-index.md
+++ b/.agents/documents/api/codebase-index.md
@@ -72,14 +72,30 @@ Unified write + status tool. Mode auto-inferred from parameters per ADR-005:
 }
 ```
 
-### 1.5 INDEX Error Codes
+### 1.5 Tool Error Contract
 
-| Scenario                 | Code                   | Behavior                                                |
-| :----------------------- | :--------------------- | :------------------------------------------------------ |
-| Path does not exist      | `PATH_NOT_FOUND`       | `{ success: false, error: "PATH_NOT_FOUND", message }`  |
-| Path is not a directory  | `NOT_A_DIRECTORY`      | `{ success: false, error: "NOT_A_DIRECTORY", message }` |
-| Index in progress        | `IndexInProgressError` | Thrown as exception; propagates as `isError: true`      |
-| Unexpected runtime error | `INDEX_FAILED`         | `{ success: false, error: "INDEX_FAILED", message }`    |
+Failed operations return `isError: true`, one concise text item, and this stable structured envelope:
+
+```typescript
+{
+	schema: "tool-error";
+	code: string;
+	message: string;
+	retryable: boolean;
+	details?: Record<string, unknown>;
+	error: string; // deprecated compatibility alias of message
+}
+```
+
+Partial bulk operations also use `isError: true` with `code: "PARTIAL_FAILURE"` while retaining successful item results at their existing top-level paths. Unknown exceptions become `INTERNAL_ERROR`; raw exception messages and filesystem details remain server-side in logs.
+
+| Scenario                 | Code                 | Retryable |
+| :----------------------- | :------------------- | :-------- |
+| Invalid arguments        | `VALIDATION_ERROR`   | No        |
+| Path does not exist      | `PATH_NOT_FOUND`     | No        |
+| Path is not a directory  | `NOT_A_DIRECTORY`    | No        |
+| Index failed internally  | `INDEX_FAILED`       | Yes       |
+| Unknown internal failure | `INTERNAL_ERROR`     | No        |
 
 ### 1.6 Runnable Examples
 

--- a/.agents/documents/decisions/ADR-007-agent-context-simplification.md
+++ b/.agents/documents/decisions/ADR-007-agent-context-simplification.md
@@ -73,19 +73,34 @@ To accommodate the structured formatting previously handled by decision-log and 
   ```
 - If no structured fields are present → content as usual
 
-### `agent-context` — Unchanged
+### `agent-context` — Token-budgeted context compiler
+
+`agent-context` remains the single read surface, but now compiles bounded context from memories, decisions, active tasks, pending handoffs, coding standards, fresh evidence-backed observations, and indexed code pointers. It is deterministic for the same stored state and inputs and does not invoke model sampling.
 
 ```jsonc
 {
-	"objective": "string", // NL query for context
-	"type_filter": "enum", // Filter memory type
-	"limit": "number (5)",
-
+	"objective": "string", // Preferred NL objective; query remains backward-compatible
+	"task_code": "string", // Pin an in-scope task as critical context
+	"current_file_path": "src/example.ts", // Enables indexed code pointers
+	"budget": { "tokens": 2000, "max_items": 20, "code_depth": 1 },
+	"sources": ["memories", "decisions", "tasks", "handoffs", "standards", "observations", "code"],
+	"include_stale": false,
+	"type_filter": "enum",
+	"limit": 5, // Legacy memories/decisions projection cap
 	"repo": "string",
 	"owner": "string (auto)",
-	"json": "boolean"
+	"json": true
 }
 ```
+
+The structured response preserves the legacy `memories`, `decisions`, and `tasks` arrays and adds:
+
+- `context[]`: selected compact items with source, id, text, provenance, and estimated token cost.
+- `allocation`: included/excluded counts and per-source accounting.
+- `exclusions[]`: candidates omitted by token or item budget.
+- `estimated_tokens` and the normalized `budget`.
+
+Token counts use a deterministic character-based estimate rather than pretending to be an exact tokenizer measurement. Every source adapter is bounded before ranking; evidence and source files are represented as pointers, not raw source dumps.
 
 ## Consequences
 

--- a/.agents/documents/operations/codebase-index.md
+++ b/.agents/documents/operations/codebase-index.md
@@ -79,7 +79,23 @@ Memory usage is bounded by the parse batch — it scales with concurrency and th
 | `DEFAULT_BATCH_SIZE`               | `number` | `100`                              | Rows per DB transaction batch (file/symbol writes). Raise for fewer transaction commits; lower to reduce write-batch memory.                                         |
 | `INDEX_STALENESS_TTL_MS`           | `number` | `30000` (30s)                      | Cache TTL for user-facing `index_status` staleness results (reduces repeated filesystem stats). Set `0` to disable caching.                                          |
 
-**Override priority** (applies to all vars): explicit `options` parameter > environment variable > hardcoded default.
+**Override priority** (applies to all vars): explicit `options` parameter > legacy environment variable > runtime profile default > hardcoded default. `MCP_RUNTIME_PROFILE` supports:
+
+- `minimal`: SQLite and lexical memory/task/handoff/standard operations only; no parser, watcher, maintenance loop, or ONNX startup.
+- `balanced`: semantic and indexing engines initialize through a single-flight loader on first demand; no proactive watcher/maintenance.
+- `full` (default): preserves the historical zero-config behavior. `CODEBASE_AUTO_INDEX=false` and `ENABLE_FILE_WATCHER=false` still disable their respective proactive paths.
+
+`codebase-index({repo, warmup:true})` explicitly initializes the parser engine. Status mode includes `runtime` with profile, per-capability state/error/duration, and current RSS/heap estimates.
+
+Measured against independent copies of a production-sized SQLite database through the bundled stdio server (`n=3`, median, Apple Silicon):
+
+| Profile    | Initialize response | RSS at initialize | RSS after 4s |
+| :--------- | ------------------: | ----------------: | -----------: |
+| `minimal`  |              503 ms |            196 MB |       184 MB |
+| `balanced` |              472 ms |            200 MB |       190 MB |
+| `full`     |            1,095 ms |            405 MB |       225 MB |
+
+The benchmark records process startup only; tool schemas and persistence are identical across profiles. Hardware/model cache affect absolute values, so compare profiles within the same run rather than treating these numbers as universal targets.
 
 ### CLI Flag: `--index`
 

--- a/.agents/documents/requirements/tdd/mcp-server.md
+++ b/.agents/documents/requirements/tdd/mcp-server.md
@@ -50,8 +50,10 @@ The system implements a local-first Model Context Protocol (MCP) server designed
 - `entities`: Knowledge graph nodes (name PK).
 - `relations`: Knowledge graph edges (composite PK).
 - `observations`: Knowledge graph observations per entity.
+- `exploration_observations`: Evidence-backed repository findings with subject, fact, confidence, task, agent, and freshness metadata.
+- `exploration_evidence`: Normalized file/symbol/line pointers for exploration observations; raw source content is never stored.
 - `action_log`: Full audit trail of all tool invocations.
-- `_schema_version`: Migration version tracking (current: v2).
+- `_schema_version`: Ordered migration history (current: v30).
 
 ## Search Algorithms
 
@@ -89,6 +91,14 @@ The system implements a local-first Model Context Protocol (MCP) server designed
 - **Library**: `compromise` for entity extraction.
 - **Trigger**: Runs on every `memory-store` via `kg-archivist.ts`.
 - **Output**: Entities stored in `entities` table, relations inferred from co-occurrence.
+
+### Exploration Observations
+
+Use `observation-write` for evidence-backed facts discovered while inspecting a repository, such as a symbol contract, dependency edge, implementation constraint, or verified defect. Every observation belongs to an `owner`/`repo` scope and must include at least one file pointer; symbol and line coordinates are optional. Bulk writes are committed in one transaction and normalized subject/fact/evidence identity makes retries idempotent.
+
+Use `observation-read` to retrieve those findings by id, subject, task, file, symbol, or confidence. Compact reads return evidence counts only; set `hydrate_evidence: true` when exact pointers are needed. Raw source text is deliberately excluded from this domain.
+
+Use `memory-write` instead for durable conclusions that should survive beyond a particular exploration run: architectural decisions, reusable patterns, mistakes, code facts worth recalling semantically, and completed-task archives. An observation is source-grounded evidence; a memory is curated long-term knowledge. Promote a validated observation into memory rather than treating both stores as interchangeable.
 
 ### Write Locking
 

--- a/.agents/documents/requirements/tdd/mcp-server.md
+++ b/.agents/documents/requirements/tdd/mcp-server.md
@@ -47,13 +47,13 @@ The system implements a local-first Model Context Protocol (MCP) server designed
 - `standard_vectors`: Embeddings for coding standard similarity search.
 - `handoffs`: Agent-to-agent context transfer with expiry.
 - `claims`: Task ownership tracking (unique per task).
-- `entities`: Knowledge graph nodes (name PK).
-- `relations`: Knowledge graph edges (composite PK).
-- `observations`: Knowledge graph observations per entity.
+- `entities`: Knowledge graph nodes scoped by composite PK `(name, repo)` (v33).
+- `relations`: Knowledge graph edges scoped by `(from_entity, to_entity, relation_type, repo)`.
+- `observations`: Knowledge graph observations with composite FK `(entity_name, repo)`.
 - `exploration_observations`: Evidence-backed repository findings with subject, fact, confidence, task, agent, and freshness metadata.
 - `exploration_evidence`: Normalized file/symbol/line pointers for exploration observations; raw source content is never stored.
 - `action_log`: Full audit trail of all tool invocations.
-- `_schema_version`: Ordered migration history (current: v31).
+- `_schema_version`: Ordered migration history (current: v33).
 
 ## Search Algorithms
 

--- a/.agents/documents/requirements/tdd/mcp-server.md
+++ b/.agents/documents/requirements/tdd/mcp-server.md
@@ -53,7 +53,7 @@ The system implements a local-first Model Context Protocol (MCP) server designed
 - `exploration_observations`: Evidence-backed repository findings with subject, fact, confidence, task, agent, and freshness metadata.
 - `exploration_evidence`: Normalized file/symbol/line pointers for exploration observations; raw source content is never stored.
 - `action_log`: Full audit trail of all tool invocations.
-- `_schema_version`: Ordered migration history (current: v30).
+- `_schema_version`: Ordered migration history (current: v31).
 
 ## Search Algorithms
 
@@ -96,7 +96,9 @@ The system implements a local-first Model Context Protocol (MCP) server designed
 
 Use `observation-write` for evidence-backed facts discovered while inspecting a repository, such as a symbol contract, dependency edge, implementation constraint, or verified defect. Every observation belongs to an `owner`/`repo` scope and must include at least one file pointer; symbol and line coordinates are optional. Bulk writes are committed in one transaction and normalized subject/fact/evidence identity makes retries idempotent.
 
-Use `observation-read` to retrieve those findings by id, subject, task, file, symbol, or confidence. Compact reads return evidence counts only; set `hydrate_evidence: true` when exact pointers are needed. Raw source text is deliberately excluded from this domain.
+Use `observation-read` to retrieve those findings by id, subject, task, file, symbol, or confidence. Compact reads return evidence counts only; set `hydrate_evidence: true` when exact pointers are needed. Stale, superseded, and unverifiable observations are excluded from list/context reads unless `include_stale: true`.
+
+Freshness is fingerprint-driven and never invokes an LLM. Each evidence pointer stores the source file checksum plus a structural symbol fingerprint (name, kind, export flags, signature, doc comment, semantic signature). Incremental indexing revalidates only the observations attached to changed files: an unchanged symbol stays `valid` even when its file changed, a changed or deleted symbol becomes `stale`, a missing index makes the observation `unverifiable` rather than silently valid, renames carry evidence pointers to the new path, and deletions mark the row stale with a reason. `observation-write.refresh_ids` is the bounded, owner/repo-scoped lazy revalidation path; a new observation may supersede an old one via `supersedes_id`. Raw source text is deliberately excluded from this domain.
 
 Use `memory-write` instead for durable conclusions that should survive beyond a particular exploration run: architectural decisions, reusable patterns, mistakes, code facts worth recalling semantically, and completed-task archives. An observation is source-grounded evidence; a memory is curated long-term knowledge. Promote a validated observation into memory rather than treating both stores as interchangeable.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,11 @@ that exit as a real failure — the coverage artifacts are still written.
 ## MCP server & tool surface
 
 - Transport is **stdio**; `src/mcp/server.ts` constructs the `McpServer` and
-  registers tools/resources/prompts. Startup also: auto-indexes its **own CWD**
-  (`CODEBASE_AUTO_INDEX`), starts the file-watcher sweep (`ENABLE_FILE_WATCHER`),
-  preloads the vector model (30s timeout), and starts the offloaded embedding worker.
+  registers tools/resources/prompts. Runtime profile `MCP_RUNTIME_PROFILE` controls
+  optional engines: `full` (default, backward-compatible eager startup), `balanced`
+  (semantic/index engines on first demand), or `minimal` (SQLite + lexical core only).
+  Legacy `CODEBASE_AUTO_INDEX` / `ENABLE_FILE_WATCHER` flags still override the full
+  profile's proactive indexing/watcher behavior.
 - **Tool contract is CANONICAL in `src/mcp/prompts/server/instructions.md`**
   (injected as the MCP server's instructions): registered tool names, auto-infer
   semantics, the who/when matrix, and micro-flows. Do NOT re-document the contract
@@ -134,16 +136,17 @@ codebase.service.ts`). The MCP server ignores it and indexes only its CWD.
   = open**), `CODEBASE_AUTO_INDEX` (`"false"` disables startup index),
   `CODEBASE_AUTO_INDEX_TTL` (default 24h), `ENABLE_FILE_WATCHER` (`"false"` disables
   the re-index sweep), `MCP_MODEL`, `CODEBASE_REPOS_DIR` (dashboard only),
-  `EMBEDDING_QUEUE_BATCH_SIZE`, `FILE_WATCH_INTERVAL_MS`. **No `GH_TOKEN`** is used
-  by this repo. **Embeddings are OFFLOADED to an async queue** (migration v9); no
-  explicit env var gate exists — the queue worker starts inline on server startup.
+  `EMBEDDING_QUEUE_BATCH_SIZE`, `FILE_WATCH_INTERVAL_MS`, `MCP_RUNTIME_PROFILE`.
+  **No `GH_TOKEN`** is used by this repo. **Embeddings are OFFLOADED to an async
+  queue** (migration v9); worker startup follows the selected runtime profile.
 - **Semantic model** `Xenova/all-MiniLM-L6-v2` is downloaded at runtime via
   `@xenova/transformers` on first search/upsert — **needs network on first use**
   unless cached.
 - **Embeddings are OFFLOADED to an async queue** (migration v9): after a
   `memory-write`/`standard-write`/`task-write`, the vector is **not instant** — there
   is a brief searchability window (typically <1s) before the semantic score converges.
-  No explicit env var gate exists — the queue worker starts inline on server startup.
+  `full` starts the queue worker eagerly; `balanced` starts it on first semantic
+  read/write; `minimal` leaves semantic enrichment unavailable while lexical tools work.
 - **Memory search uses FTS5** (migration v10) with the `unicode61` tokenizer and `*`
   prefix matching — mid-word substring matches are **not** guaranteed (trigram deferred).
 
@@ -164,6 +167,7 @@ worker starts inline at startup).
 | `LOG_LEVEL`           | `info`                           | Log level (`trace`/`debug`/`info`/`warn`/`error`), lowercased.       |
 | `MCP_CLIENT_NAME`     | — (session fallback)             | Default agent name when a tool call omits `agent`.                   |
 | `MCP_MODEL`           | — (session fallback)             | Default model when a tool call omits `model`.                        |
+| `MCP_RUNTIME_PROFILE` | `full`                           | `minimal`, `balanced`, or backward-compatible `full`.                |
 | `ENABLE_AUTO_ARCHIVE` | `"false"` (disabled)             | Set to `"true"` to enable automatic memory archiving on startup.     |
 
 ### Dashboard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,15 +160,18 @@ worker starts inline at startup).
 
 ### MCP core
 
-| Variable              | Default                          | Purpose                                                              |
-| :-------------------- | :------------------------------- | :------------------------------------------------------------------- |
-| `MEMORY_DB_PATH`      | — (platform config dir fallback) | Explicit SQLite DB path override.                                    |
-| `MCP_SERVER`          | set to `"true"` by `server.ts`   | Marks the running process as the MCP server (affects logging/sinks). |
-| `LOG_LEVEL`           | `info`                           | Log level (`trace`/`debug`/`info`/`warn`/`error`), lowercased.       |
-| `MCP_CLIENT_NAME`     | — (session fallback)             | Default agent name when a tool call omits `agent`.                   |
-| `MCP_MODEL`           | — (session fallback)             | Default model when a tool call omits `model`.                        |
-| `MCP_RUNTIME_PROFILE` | `full`                           | `minimal`, `balanced`, or backward-compatible `full`.                |
-| `ENABLE_AUTO_ARCHIVE` | `"false"` (disabled)             | Set to `"true"` to enable automatic memory archiving on startup.     |
+| Variable                         | Default                          | Purpose                                                              |
+| :------------------------------- | :------------------------------- | :------------------------------------------------------------------- |
+| `MEMORY_DB_PATH`                 | — (platform config dir fallback) | Explicit SQLite DB path override.                                    |
+| `MCP_SERVER`                     | set to `"true"` by `server.ts`   | Marks the running process as the MCP server (affects logging/sinks). |
+| `LOG_LEVEL`                      | `info`                           | Log level (`trace`/`debug`/`info`/`warn`/`error`), lowercased.       |
+| `MCP_CLIENT_NAME`                | — (session fallback)             | Default agent name when a tool call omits `agent`.                   |
+| `MCP_MODEL`                      | — (session fallback)             | Default model when a tool call omits `model`.                        |
+| `MCP_RUNTIME_PROFILE`            | `full`                           | `minimal`, `balanced`, or backward-compatible `full`.                |
+| `ENABLE_AUTO_ARCHIVE`            | `"false"` (disabled)             | Set to `"true"` to enable automatic memory archiving on startup.     |
+| `ENABLE_REUSE_TELEMETRY`         | `"true"`                         | Set to `"false"` to disable aggregate-only context-reuse telemetry.  |
+| `REUSE_TELEMETRY_RETENTION_DAYS` | `30`                             | Hourly aggregate retention in days (bounded to 1–365).               |
+| `REUSE_TELEMETRY_MAX_ROWS`       | `20000`                          | Global cap for aggregate telemetry rows.                             |
 
 ### Dashboard
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"test:perf": "vitest --run --project perf",
 		"test:unit": "vitest --run --project unit",
 		"test:watch": "vitest",
+		"bench:context-reuse": "node --expose-gc --import tsx scripts/bench/context-reuse-bench.ts",
 		"type-check": "tsc --noEmit && tsc -p tsconfig.test.json && svelte-check --tsconfig ./src/dashboard/ui/tsconfig.json",
 		"lint": "eslint . --ext .ts,.svelte",
 		"lint:fix": "eslint . --ext .ts,.svelte --fix",

--- a/scripts/bench/concurrent-eval/lifecycle.mjs
+++ b/scripts/bench/concurrent-eval/lifecycle.mjs
@@ -3,7 +3,6 @@ import path from "path";
 import { createHash, randomUUID } from "crypto";
 import { execSync } from "child_process";
 import { createConcurrentBenchDb } from "./schema.mjs";
-import { BENCH_EPOCH_ISO } from "./constants.mjs";
 
 export function withConcurrentBenchDb(tmpDir, label, fn) {
 	const dbPath = `${tmpDir}/${label}-${randomUUID()}.db`;
@@ -13,11 +12,15 @@ export function withConcurrentBenchDb(tmpDir, label, fn) {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }
@@ -30,11 +33,15 @@ export async function withConcurrentBenchDbAsync(tmpDir, label, fn) {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }
@@ -45,7 +52,7 @@ export function collectBenchRevision() {
 	const corpusRoot = path.resolve("scripts/bench/memory-eval");
 	const discovered = [];
 	const walk = (dir) => {
-		let entries = [];
+		let entries;
 		try {
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch {

--- a/scripts/bench/concurrent-eval/report.mjs
+++ b/scripts/bench/concurrent-eval/report.mjs
@@ -1,4 +1,4 @@
-import { percentiles, throughput } from "../memory-eval/metrics.mjs";
+import { percentiles } from "../memory-eval/metrics.mjs";
 
 export function toLatencyStats(samples) {
 	if (!samples || samples.length === 0) return { p50: 0, p95: 0, p99: 0, mean: 0, min: 0, max: 0, n: 0 };

--- a/scripts/bench/concurrent-eval/scenarios/mixed.mjs
+++ b/scripts/bench/concurrent-eval/scenarios/mixed.mjs
@@ -88,7 +88,9 @@ export async function measureScenarioMixed(tmpDir, seedCorpus) {
 		let heapBytes = null;
 		try {
 			heapBytes = process.memoryUsage().heapUsed;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		let dbBytes = null;
 		let walBytes = null;
 		try {
@@ -100,7 +102,9 @@ export async function measureScenarioMixed(tmpDir, seedCorpus) {
 				walBytes = 0;
 			}
 			dbBytes += walBytes;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		const elapsedMs = performance.now() - scenarioStart;
 		return {
 			latencies,
@@ -137,11 +141,15 @@ export async function measureScenarioMixed(tmpDir, seedCorpus) {
 	} finally {
 		try {
 			primaryDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }

--- a/scripts/bench/concurrent-eval/scenarios/multi-client.mjs
+++ b/scripts/bench/concurrent-eval/scenarios/multi-client.mjs
@@ -171,21 +171,29 @@ export async function measureScenarioMultiClient(tmpDir, seedCorpus) {
 		for (const worker of workers) {
 			try {
 				await worker.terminate();
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 		for (const child of children) {
 			try {
 				child.kill("SIGTERM");
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 		try {
 			primaryDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		barrier.close();
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }

--- a/scripts/bench/concurrent-eval/scenarios/readers-only.mjs
+++ b/scripts/bench/concurrent-eval/scenarios/readers-only.mjs
@@ -5,7 +5,6 @@ import { randomUUID } from "crypto";
 import { Worker } from "node:worker_threads";
 import { fileURLToPath } from "url";
 import { createConcurrentBenchDb } from "../schema.mjs";
-import { OWNER } from "../constants.mjs";
 
 export async function measureScenarioReadersOnly(tmpDir, seedCorpus) {
 	const dbPath = path.join(tmpDir, `concurrent-readers-${randomUUID()}.db`);
@@ -76,7 +75,9 @@ export async function measureScenarioReadersOnly(tmpDir, seedCorpus) {
 		let heapBytes = null;
 		try {
 			heapBytes = process.memoryUsage().heapUsed;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		let dbBytes = null;
 		let walBytes = null;
 		try {
@@ -88,7 +89,9 @@ export async function measureScenarioReadersOnly(tmpDir, seedCorpus) {
 				walBytes = 0;
 			}
 			dbBytes += walBytes;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		const elapsedMs = performance.now() - scenarioStart;
 		return {
 			latencies,
@@ -113,11 +116,15 @@ export async function measureScenarioReadersOnly(tmpDir, seedCorpus) {
 	} finally {
 		try {
 			primaryDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }

--- a/scripts/bench/concurrent-eval/scenarios/writers-only.mjs
+++ b/scripts/bench/concurrent-eval/scenarios/writers-only.mjs
@@ -76,7 +76,9 @@ export async function measureScenarioWritersOnly(tmpDir, seedCorpus) {
 		let heapBytes = null;
 		try {
 			heapBytes = process.memoryUsage().heapUsed;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		let dbBytes = null;
 		let walBytes = null;
 		try {
@@ -88,7 +90,9 @@ export async function measureScenarioWritersOnly(tmpDir, seedCorpus) {
 				walBytes = 0;
 			}
 			dbBytes += walBytes;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		const elapsedMs = performance.now() - scenarioStart;
 		return {
 			latencies,
@@ -113,11 +117,15 @@ export async function measureScenarioWritersOnly(tmpDir, seedCorpus) {
 	} finally {
 		try {
 			primaryDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }

--- a/scripts/bench/concurrent-eval/workers/concurrent-reader.worker.mjs
+++ b/scripts/bench/concurrent-eval/workers/concurrent-reader.worker.mjs
@@ -82,5 +82,7 @@ try {
 } finally {
 	try {
 		db.close();
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 }

--- a/scripts/bench/concurrent-eval/workers/concurrent-writer-concurrent.worker.mjs
+++ b/scripts/bench/concurrent-eval/workers/concurrent-writer-concurrent.worker.mjs
@@ -13,8 +13,6 @@ const data = workerData?.dbPath
 			barrierPath: process.env.CONCURRENT_BARRIER_PATH
 		};
 const isChild = !parentPort;
-const barrier = data.barrierPath ? await import("../barrier.mjs") : null;
-const barrierHandle = barrier && barrier.createFileBarrier ? null : null;
 if (data.barrierPath) {
 	const fs = await import("node:fs");
 	const deadline = Date.now() + 20000;
@@ -118,5 +116,7 @@ try {
 } finally {
 	try {
 		db.close();
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 }

--- a/scripts/bench/concurrent-workload-bench.mjs
+++ b/scripts/bench/concurrent-workload-bench.mjs
@@ -26,7 +26,9 @@ function resourceSnapshot(dbPath) {
 	let heapBytes = null;
 	try {
 		heapBytes = process.memoryUsage().heapUsed;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 	let dbBytes = null;
 	let walBytes = null;
 	try {
@@ -37,7 +39,9 @@ function resourceSnapshot(dbPath) {
 			walBytes = 0;
 		}
 		dbBytes += walBytes;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 	return { heapBytes, dbBytes, walBytes };
 }
 
@@ -122,7 +126,9 @@ async function main() {
 		referenceSqliteVersion = probe.prepare("SELECT sqlite_version()").pluck().get();
 		referencePageSize = probe.pragma("page_size", { simple: true });
 		probe.close();
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 	const seedForScenario = (db) => seedCorpus(db);
 	const scenarioFns = {
 		readers_only: measureScenarioReadersOnly,
@@ -171,15 +177,21 @@ async function main() {
 		let commitSha = null;
 		try {
 			commitSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim() || null;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		let branch = null;
 		try {
 			branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim() || null;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		let dirty = false;
 		try {
 			dirty = execSync("git status --porcelain", { encoding: "utf8" }).trim().length > 0;
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		const result = {
 			meta: {
 				task: "TASK-480",

--- a/scripts/bench/context-reuse-bench.ts
+++ b/scripts/bench/context-reuse-bench.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { SQLiteStore } from "../../src/mcp/storage/sqlite";
+import { ReuseTelemetry } from "../../src/mcp/utils/reuse-telemetry";
+
+const OWNER = "bench-owner";
+const REPO = "context-reuse-bench";
+const FILES = 12;
+const SYMBOLS = 24;
+const EVIDENCE_POINTERS = 8;
+const TOKEN_PER_READ = 96;
+const ROUNDS = 2;
+
+function runScenario(store: SQLiteStore, shared: boolean) {
+	const readFiles = store.db.prepare("SELECT id, file_path FROM bench_files ORDER BY id");
+	const readSymbols = store.db.prepare("SELECT id, name FROM bench_symbols ORDER BY id");
+	const readEvidence = store.db.prepare("SELECT file_id, symbol_id FROM bench_evidence ORDER BY file_id, symbol_id");
+	const started = performance.now();
+	let fileReads = 0;
+	let symbolReads = 0;
+	let evidenceReads = 0;
+	let estimatedTokens = 0;
+	if (shared) {
+		fileReads += readFiles.all().length;
+		symbolReads += readSymbols.all().length;
+		estimatedTokens += (fileReads + symbolReads) * TOKEN_PER_READ;
+		for (let consumer = 0; consumer < 3; consumer++) {
+			evidenceReads += readEvidence.all().length;
+			estimatedTokens += EVIDENCE_POINTERS * TOKEN_PER_READ;
+		}
+	} else {
+		for (let round = 0; round < ROUNDS; round++) {
+			for (let agent = 0; agent < 2; agent++) {
+				fileReads += readFiles.all().length;
+				symbolReads += readSymbols.all().length;
+				estimatedTokens += (FILES + SYMBOLS) * TOKEN_PER_READ;
+			}
+		}
+	}
+	return { fileReads, symbolReads, evidenceReads, estimatedTokens, latencyMs: performance.now() - started };
+}
+
+function workload(store: SQLiteStore, telemetry: ReuseTelemetry, enabled: boolean) {
+	const calls = 500;
+	const query = store.db.prepare("SELECT ? AS value");
+	const cpuStarted = process.cpuUsage();
+	const started = performance.now();
+	for (let index = 0; index < calls; index++) {
+		for (let read = 0; read < 10_000; read++) query.get(index + read);
+		telemetry.recordTool({
+			owner: OWNER,
+			repo: REPO,
+			session: "bench-session",
+			toolName: enabled ? "codebase-read" : "untracked-read",
+			args: { filePath: `src/file-${index & 63}.ts` },
+			result: {}
+		});
+	}
+	telemetry.flush(store);
+	const cpu = process.cpuUsage(cpuStarted);
+	return { wallMs: performance.now() - started, cpuMs: (cpu.user + cpu.system) / 1_000 };
+}
+
+function median(values: number[]): number {
+	return [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)]!;
+}
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "context-reuse-bench-"));
+const dbPath = path.join(tmpDir, "telemetry.db");
+try {
+	const store = new SQLiteStore(dbPath);
+	store.db.exec(`
+		CREATE TABLE bench_files (id INTEGER PRIMARY KEY, file_path TEXT NOT NULL);
+		CREATE TABLE bench_symbols (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+		CREATE TABLE bench_evidence (file_id INTEGER NOT NULL, symbol_id INTEGER NOT NULL);
+	`);
+	const seed = store.db.transaction(() => {
+		for (let index = 0; index < FILES; index++)
+			store.db.prepare("INSERT INTO bench_files VALUES (?, ?)").run(index, `file-${index}`);
+		for (let index = 0; index < SYMBOLS; index++)
+			store.db.prepare("INSERT INTO bench_symbols VALUES (?, ?)").run(index, `symbol-${index}`);
+		for (let index = 0; index < EVIDENCE_POINTERS; index++)
+			store.db.prepare("INSERT INTO bench_evidence VALUES (?, ?)").run(index % FILES, index % SYMBOLS);
+	});
+	seed();
+	store.db.pragma("wal_checkpoint(TRUNCATE)");
+	const dbBytesBefore = fs.statSync(dbPath).size;
+	const disabled = new ReuseTelemetry(false);
+	const enabled = new ReuseTelemetry(true);
+	for (let index = 0; index < 3; index++) workload(store, disabled, false);
+	globalThis.gc?.();
+	const baselineTrials: Array<{ wallMs: number; cpuMs: number }> = [];
+	const enabledTrials: Array<{ wallMs: number; cpuMs: number }> = [];
+	const heapBefore = process.memoryUsage().heapUsed;
+	for (let index = 0; index < 7; index++) {
+		baselineTrials.push(workload(store, disabled, false));
+		enabledTrials.push(workload(store, enabled, true));
+	}
+	globalThis.gc?.();
+	store.db.pragma("wal_checkpoint(TRUNCATE)");
+	const heapDeltaBytes = Math.max(0, process.memoryUsage().heapUsed - heapBefore);
+	const baselineMs = median(baselineTrials.map((trial) => trial.wallMs));
+	const instrumentedMs = median(enabledTrials.map((trial) => trial.wallMs));
+	const baselineCpuMs = median(baselineTrials.map((trial) => trial.cpuMs));
+	const instrumentedCpuMs = median(enabledTrials.map((trial) => trial.cpuMs));
+	const baseline = runScenario(store, false);
+	const shared = runScenario(store, true);
+	console.log(
+		JSON.stringify(
+			{
+				seed: 96,
+				scenario: "explore -> orchestrator -> two implementers",
+				baseline,
+				shared,
+				delta: {
+					fileReadsAvoided: baseline.fileReads - shared.fileReads,
+					symbolReadsAvoided: baseline.symbolReads - shared.symbolReads,
+					estimatedTokensAvoided: baseline.estimatedTokens - shared.estimatedTokens
+				},
+				telemetry: {
+					baselineMs,
+					instrumentedMs,
+					wallOverheadPercent: ((instrumentedMs - baselineMs) / baselineMs) * 100,
+					baselineCpuMs,
+					instrumentedCpuMs,
+					cpuOverheadPercent: ((instrumentedCpuMs - baselineCpuMs) / baselineCpuMs) * 100,
+					heapDeltaBytes,
+					dbBytes: fs.statSync(dbPath).size,
+					dbGrowthBytes: fs.statSync(dbPath).size - dbBytesBefore,
+					rows: (store.db.prepare("SELECT COUNT(*) AS count FROM reuse_telemetry_hourly").get() as { count: number })
+						.count
+				}
+			},
+			null,
+			2
+		)
+	);
+	store.close();
+} finally {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/scripts/bench/embedding-eval/lifecycle.mjs
+++ b/scripts/bench/embedding-eval/lifecycle.mjs
@@ -1,9 +1,8 @@
 import fs from "fs";
 import path from "path";
 import { randomUUID } from "crypto";
-import { createHash, randomBytes } from "crypto";
+import { createHash } from "crypto";
 import { execSync } from "child_process";
-import { performance } from "node:perf_hooks";
 import { createBenchDb } from "./schema.mjs";
 import { contentHash } from "./fixtures.mjs";
 import { BATCH_SIZE, LEASE_MS, POISON_THRESHOLD, BACKOFF_BASE_MS, BACKOFF_MAX_MS } from "./constants.mjs";
@@ -16,11 +15,15 @@ export function withBenchDb(tmpDir, label, fn) {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup or callback isolation.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or callback isolation.
+			}
 		}
 	}
 }
@@ -33,11 +36,15 @@ export async function withBenchDbAsync(tmpDir, label, fn) {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup or callback isolation.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or callback isolation.
+			}
 		}
 	}
 }
@@ -157,7 +164,7 @@ export function collectBenchRevision() {
 	const evalRoot = path.resolve("scripts/bench/embedding-eval");
 	const discovered = [];
 	const walk = (dir) => {
-		let entries = [];
+		let entries;
 		try {
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch {
@@ -266,7 +273,9 @@ export async function drainAll(db, opts = {}) {
 			if (onVisible) {
 				try {
 					onVisible(job.entity_id, Date.now());
-				} catch {}
+				} catch {
+					// Best-effort benchmark cleanup or callback isolation.
+				}
 			}
 			totalProcessed++;
 		}

--- a/scripts/bench/embedding-eval/scenarios/concurrent-writes.mjs
+++ b/scripts/bench/embedding-eval/scenarios/concurrent-writes.mjs
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { performance } from "node:perf_hooks";
 import { randomUUID } from "crypto";
 import { Worker } from "node:worker_threads";
 import { createBenchDb } from "../schema.mjs";
@@ -123,11 +122,15 @@ export async function measureScenarioConcurrentWrites(tmpDir) {
 	} finally {
 		try {
 			primaryDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }

--- a/scripts/bench/embedding-eval/scenarios/lease-expiry.mjs
+++ b/scripts/bench/embedding-eval/scenarios/lease-expiry.mjs
@@ -1,4 +1,3 @@
-import { performance } from "node:perf_hooks";
 import { BENCH_EPOCH_MS } from "../../memory-eval/corpus.mjs";
 import { makeMemoryEntry } from "../fixtures.mjs";
 import { withBenchDbAsync, writeWithEnqueue, claimBatch, drainAll, reconcileExpiredLeases } from "../lifecycle.mjs";

--- a/scripts/bench/embedding-eval/scenarios/worker-restart.mjs
+++ b/scripts/bench/embedding-eval/scenarios/worker-restart.mjs
@@ -1,6 +1,4 @@
-import fs from "fs";
 import path from "path";
-import os from "os";
 import { performance } from "node:perf_hooks";
 import { randomUUID } from "crypto";
 import { spawn } from "node:child_process";
@@ -22,7 +20,7 @@ function onceJsonReadyOrClose(proc) {
 		let out = "";
 		let errOut = "";
 		let settled = false;
-		const tryParse = (payload, code) => {
+		const tryParse = (payload) => {
 			const trimmed = payload.trim();
 			if (!trimmed) return null;
 			const lines = trimmed.split("\n").filter(Boolean);
@@ -30,7 +28,9 @@ function onceJsonReadyOrClose(proc) {
 				try {
 					const parsed = JSON.parse(lines[i]);
 					if (parsed.ok) return parsed;
-				} catch {}
+				} catch {
+					// Best-effort benchmark cleanup or process termination.
+				}
 			}
 			return null;
 		};
@@ -85,11 +85,11 @@ export async function measureScenarioWorkerRestart(tmpDir) {
 	} finally {
 		try {
 			seedDb.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup or process termination.
+		}
 	}
 	const enqueueAt = mems.map((m) => ({ id: m.id, t0: m.t0 }));
-	const ids = mems.map((m) => m.id);
-	const enqueueMap = new Map(enqueueAt.map((e) => [e.id, e.t0]));
 
 	const claimProc = spawnWorker(dbPath, "claim");
 	let claimRes;
@@ -103,12 +103,16 @@ export async function measureScenarioWorkerRestart(tmpDir) {
 				claimProc.kill("SIGKILL");
 				killedLiveWorker = true;
 				await new Promise((r) => claimProc.once("close", r));
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or process termination.
+			}
 		}
 	} catch (e) {
 		try {
 			claimProc.kill("SIGKILL");
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup or process termination.
+		}
 		const pendingMid = (() => {
 			try {
 				const db = createBenchDb(dbPath);

--- a/scripts/bench/embedding-eval/workers/concurrent-writer.worker.mjs
+++ b/scripts/bench/embedding-eval/workers/concurrent-writer.worker.mjs
@@ -23,7 +23,6 @@ try {
 		const id = `30000000-0000-4000-a000-${String(i + 1).padStart(12, "0")}`;
 		const mem = makeMemoryEntry(id, new Date(BENCH_EPOCH_MS + i * 10).toISOString(), 9000 + i);
 		let attempt = 0;
-		let done = false;
 		while (attempt < 3) {
 			const tPerf0 = performance.now();
 			const tWall0 = Date.now();
@@ -33,7 +32,6 @@ try {
 				writeLatencies.push(lat);
 				enqueues.push({ id, t0: tWall0, writer: writerIndex });
 				attemptsLog.push({ id, writer: writerIndex, contended: attempt > 0 });
-				done = true;
 				break;
 			} catch (e) {
 				const msg = String(e?.message || e);
@@ -50,8 +48,6 @@ try {
 				break;
 			}
 		}
-		if (!done && attempt >= 3) {
-		}
 	}
 	parentPort.postMessage({
 		ok: true,
@@ -66,5 +62,7 @@ try {
 } finally {
 	try {
 		db.close();
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup.
+	}
 }

--- a/scripts/bench/embedding-eval/workers/restart.worker.mjs
+++ b/scripts/bench/embedding-eval/workers/restart.worker.mjs
@@ -1,4 +1,3 @@
-import path from "path";
 import { performance } from "node:perf_hooks";
 import { BENCH_EPOCH_MS } from "../../memory-eval/corpus.mjs";
 import { makeMemoryEntry } from "../fixtures.mjs";
@@ -29,7 +28,9 @@ if (op === "seed") {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 	}
 } else if (op === "claim") {
 	const db = createBenchDb(dbPath);
@@ -66,7 +67,9 @@ if (op === "seed") {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 	}
 } else if (op === "recover") {
 	const enqueueRaw = process.argv[4];
@@ -130,7 +133,9 @@ if (op === "seed") {
 	} finally {
 		try {
 			db2.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 	}
 } else {
 	console.error(JSON.stringify({ ok: false, error: `unknown op ${op}` }));

--- a/scripts/bench/embedding-queue-availability-bench.mjs
+++ b/scripts/bench/embedding-queue-availability-bench.mjs
@@ -5,7 +5,7 @@ import path from "path";
 import { execSync } from "child_process";
 import { createRequire } from "module";
 import Database from "better-sqlite3";
-import { percentiles, throughput } from "./memory-eval/metrics.mjs";
+import { throughput } from "./memory-eval/metrics.mjs";
 import { BENCH_EPOCH_ISO } from "./memory-eval/corpus.mjs";
 import {
 	SEED,
@@ -46,19 +46,27 @@ async function main() {
 	let betterSqlite3Version = null;
 	try {
 		betterSqlite3Version = require("better-sqlite3/package.json").version;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup or metadata collection.
+	}
 	let commitSha = null;
 	try {
 		commitSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim() || null;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup or metadata collection.
+	}
 	let branch = null;
 	try {
 		branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim() || null;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup or metadata collection.
+	}
 	let dirty = false;
 	try {
 		dirty = execSync("git status --porcelain", { encoding: "utf8" }).trim().length > 0;
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup or metadata collection.
+	}
 	const benchRevision = collectBenchRevision();
 	let referenceSqliteVersion = null;
 	let referencePageSize = null;
@@ -67,7 +75,9 @@ async function main() {
 		referenceSqliteVersion = probe.prepare("SELECT sqlite_version()").pluck().get();
 		referencePageSize = probe.pragma("page_size", { simple: true });
 		probe.close();
-	} catch {}
+	} catch {
+		// Best-effort benchmark cleanup or metadata collection.
+	}
 	const scenarios = {};
 	const errors = [];
 	const run = async (name, fn) => {
@@ -228,7 +238,9 @@ async function main() {
 	} finally {
 		try {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup or metadata collection.
+		}
 	}
 }
 

--- a/scripts/bench/memory-write-search-bench.mjs
+++ b/scripts/bench/memory-write-search-bench.mjs
@@ -333,8 +333,6 @@ async function main() {
 	const scaleResults = [];
 
 	try {
-		const betterSqlite3Version = require("better-sqlite3/package.json").version;
-
 		for (const rows of scales) {
 			const scaleTmpDir = path.join(tmpDir, `scale-${rows}`);
 			fs.mkdirSync(scaleTmpDir, { recursive: true });
@@ -655,7 +653,9 @@ async function main() {
 				if (db?.open) {
 					try {
 						db.close();
-					} catch {}
+					} catch {
+						// Best-effort benchmark cleanup or metadata collection.
+					}
 					db = null;
 				}
 				const msg = String(err?.message || err);
@@ -668,7 +668,9 @@ async function main() {
 				if (db?.open) {
 					try {
 						db.close();
-					} catch {}
+					} catch {
+						// Best-effort benchmark cleanup or metadata collection.
+					}
 				}
 			}
 		}
@@ -690,7 +692,9 @@ async function main() {
 				referenceSqliteVersion = probe.prepare("SELECT sqlite_version()").pluck().get();
 				referencePageSize = probe.pragma("page_size", { simple: true });
 				probe.close();
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or metadata collection.
+			}
 		}
 
 		const lastScale = scaleResults[scaleResults.length - 1];
@@ -699,11 +703,15 @@ async function main() {
 			let dirty = false;
 			try {
 				branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim() || null;
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or metadata collection.
+			}
 			try {
 				const porcel = execSync("git status --porcelain", { encoding: "utf8" }).trim();
 				dirty = porcel.length > 0;
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup or metadata collection.
+			}
 			return { branch, dirty };
 		})();
 		const benchRevision = (() => {

--- a/scripts/bench/midword-eval/lifecycle.mjs
+++ b/scripts/bench/midword-eval/lifecycle.mjs
@@ -53,11 +53,15 @@ export function withBenchDb(tmpDir, label, fn) {
 	} finally {
 		try {
 			db.close();
-		} catch {}
+		} catch {
+			// Best-effort benchmark cleanup.
+		}
 		for (const suffix of ["", "-wal", "-shm"]) {
 			try {
 				fs.unlinkSync(`${dbPath}${suffix}`);
-			} catch {}
+			} catch {
+				// Best-effort benchmark cleanup.
+			}
 		}
 	}
 }
@@ -73,7 +77,7 @@ export function collectBenchRevision() {
 	const evalRoot = path.resolve("scripts/bench/midword-eval");
 	const discovered = [];
 	const walk = (dir) => {
-		let entries = [];
+		let entries;
 		try {
 			entries = fs.readdirSync(dir, { withFileTypes: true });
 		} catch {

--- a/scripts/bench/midword-fallback-bench.mjs
+++ b/scripts/bench/midword-fallback-bench.mjs
@@ -33,12 +33,10 @@ import os from "os";
 import path from "path";
 import { execSync } from "child_process";
 import { createRequire } from "module";
-import Database from "better-sqlite3";
-
-import { buildCorpus, buildStressCorpus, SEED, OWNER, REPO } from "./midword-eval/corpus.mjs";
+import { buildCorpus, SEED, OWNER, REPO } from "./midword-eval/corpus.mjs";
 import { QUERIES, createOracle, runFtsBaseline } from "./midword-eval/queries.mjs";
 import { percentiles, recallAt, recallFull } from "./midword-eval/metrics.mjs";
-import { midwordScan, runFallback, DEFAULT_OPTS } from "./midword-eval/fallback.mjs";
+import { midwordScan, DEFAULT_OPTS } from "./midword-eval/fallback.mjs";
 import { createBenchDb, collectBenchRevision } from "./midword-eval/lifecycle.mjs";
 import { printReport, writeResult } from "./midword-eval/report.mjs";
 
@@ -71,19 +69,27 @@ async function main() {
 	let betterSqlite3Version = null;
 	try {
 		betterSqlite3Version = require("better-sqlite3/package.json").version;
-	} catch {}
+	} catch {
+		// Optional metadata or cleanup is best-effort.
+	}
 	let commitSha = null;
 	let branch = null;
 	let dirty = false;
 	try {
 		commitSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim() || null;
-	} catch {}
+	} catch {
+		// Optional metadata or cleanup is best-effort.
+	}
 	try {
 		branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim() || null;
-	} catch {}
+	} catch {
+		// Optional metadata or cleanup is best-effort.
+	}
 	try {
 		dirty = execSync("git status --porcelain", { encoding: "utf8" }).trim().length > 0;
-	} catch {}
+	} catch {
+		// Optional metadata or cleanup is best-effort.
+	}
 	const benchRevision = collectBenchRevision();
 
 	const errors = [];
@@ -352,7 +358,9 @@ async function main() {
 		if (db?.open) {
 			try {
 				db.close();
-			} catch {}
+			} catch {
+				// Optional metadata or cleanup is best-effort.
+			}
 		}
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	}

--- a/src/dashboard/controllers/KGController.ts
+++ b/src/dashboard/controllers/KGController.ts
@@ -32,8 +32,10 @@ export class KGController {
 	static async getEntity(req: express.Request, res: express.Response) {
 		await handleController(req, res, () => {
 			const name = req.params.name as string;
+			const repo = req.query.repo as string;
+			if (!repo) throw new HttpError(400, "repo is required");
 
-			const result = KgService.getEntity(name);
+			const result = KgService.getEntity(name, repo);
 			return jsonApiRes(result, "entity");
 		});
 	}
@@ -107,9 +109,9 @@ export class KGController {
 	static async createEntity(req: express.Request, res: express.Response) {
 		await handleController(req, res, async () => {
 			const attributes = getAttributes(req);
-			const { name } = attributes;
+			const { name, repo } = attributes;
 
-			if (!name) throw new HttpError(400, "name is required");
+			if (!name || !repo) throw new HttpError(400, "name and repo are required");
 
 			const entity = await KgService.createEntity(attributes);
 			return jsonApiRes(entity, "entity");
@@ -119,8 +121,10 @@ export class KGController {
 	static async deleteEntity(req: express.Request, res: express.Response) {
 		await handleController(req, res, async () => {
 			const name = req.params.name as string;
+			const repo = req.query.repo as string;
+			if (!repo) throw new HttpError(400, "repo is required");
 
-			const result = await KgService.deleteEntity(name);
+			const result = await KgService.deleteEntity(name, repo);
 			return jsonApiRes(result, "status");
 		});
 	}
@@ -128,10 +132,10 @@ export class KGController {
 	static async createRelation(req: express.Request, res: express.Response) {
 		await handleController(req, res, async () => {
 			const attributes = getAttributes(req);
-			const { from_entity, to_entity, relation_type } = attributes;
+			const { from_entity, to_entity, relation_type, repo } = attributes;
 
-			if (!from_entity || !to_entity || !relation_type) {
-				throw new HttpError(400, "from_entity, to_entity, and relation_type are required");
+			if (!from_entity || !to_entity || !relation_type || !repo) {
+				throw new HttpError(400, "from_entity, to_entity, relation_type, and repo are required");
 			}
 
 			const result = await KgService.createRelation(attributes);
@@ -142,13 +146,13 @@ export class KGController {
 	static async deleteRelation(req: express.Request, res: express.Response) {
 		await handleController(req, res, async () => {
 			const attributes = getAttributes(req);
-			const { from_entity, to_entity, relation_type } = attributes;
+			const { from_entity, to_entity, relation_type, repo } = attributes;
 
-			if (!from_entity || !to_entity || !relation_type) {
-				throw new HttpError(400, "from_entity, to_entity, and relation_type are required");
+			if (!from_entity || !to_entity || !relation_type || !repo) {
+				throw new HttpError(400, "from_entity, to_entity, relation_type, and repo are required");
 			}
 
-			const result = await KgService.deleteRelation(from_entity, to_entity, relation_type);
+			const result = await KgService.deleteRelation(from_entity, to_entity, relation_type, repo);
 			return jsonApiRes(result, "status");
 		});
 	}

--- a/src/dashboard/controllers/SystemController.ts
+++ b/src/dashboard/controllers/SystemController.ts
@@ -43,7 +43,16 @@ export class SystemController {
 			req,
 			res,
 			() => {
-				return jsonApiRes(SystemService.getMetrics(), "system-metrics");
+				const repoInput = req.query.repo as string | undefined;
+				let owner = req.query.owner as string | undefined;
+				let repo = repoInput;
+				if (!owner && repoInput?.includes("/")) {
+					const parsed = parseRepoInput(repoInput, undefined);
+					owner = parsed.owner;
+					repo = parsed.repo;
+				}
+				const hours = Math.max(1, Math.min(24 * 90, Number(req.query.hours) || 24));
+				return jsonApiRes(SystemService.getMetrics(owner, repo, hours), "system-metrics");
 			},
 			{ refresh: false }
 		);

--- a/src/dashboard/lib/context.ts
+++ b/src/dashboard/lib/context.ts
@@ -1,13 +1,18 @@
 import { MCPClient } from "../../mcp/client";
 import { SQLiteStore } from "../../mcp/storage/sqlite";
 import { RealVectorStore } from "../../mcp/storage/vectors";
+import { CapabilityAwareVectorStore } from "../../mcp/storage/lazy-vectors";
 import { EmbeddingWorker } from "../../mcp/embedding-queue";
+import { RuntimeCapabilityRegistry, setRuntimeCapabilities } from "../../mcp/runtime-capabilities";
 import { EMBEDDING_QUEUE_BACKFILL_CAP } from "../../mcp/utils/constants";
 import { logger } from "../../mcp/utils/logger";
 
 export const db = await SQLiteStore.create();
 export const mcpClient = new MCPClient();
-export const vectors = new RealVectorStore(db);
+const realVectors = new RealVectorStore(db);
+export const runtimeCapabilities = new RuntimeCapabilityRegistry();
+setRuntimeCapabilities(runtimeCapabilities);
+export const vectors = new CapabilityAwareVectorStore(realVectors, runtimeCapabilities);
 // Embedding/KG outbox worker (TASK-013): the dashboard shares the SQLite
 // queue_jobs table with the MCP server — atomic claims serialize work across
 // processes. Started by dashboard/server.ts.
@@ -25,10 +30,12 @@ export const vectors = new RealVectorStore(db);
 // the queue-depth gate (EMBEDDING_QUEUE_BACKFILL_MIN_QUEUE) prevents a deep
 // backlog being double-refilled. Set EMBEDDING_QUEUE_BACKFILL_CAP=0 to restore
 // single-owner (MCP-server-only) backfill.
-export const embeddingWorker = new EmbeddingWorker(db, vectors, { backfillCap: EMBEDDING_QUEUE_BACKFILL_CAP });
+export const embeddingWorker = new EmbeddingWorker(db, realVectors, { backfillCap: EMBEDDING_QUEUE_BACKFILL_CAP });
+runtimeCapabilities.register("semantic", async () => {
+	await realVectors.initialize();
+	embeddingWorker.start();
+});
+runtimeCapabilities.markReady("dashboard");
+if (runtimeCapabilities.profile === "full") void runtimeCapabilities.ensure("semantic");
 export const startTime = Date.now();
 export { logger };
-
-vectors.initialize().catch((err) => {
-	logger.warn("[Dashboard] Initial vector model loading failed. Will retry on first use.", { error: String(err) });
-});

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import { fileURLToPath } from "url";
 import { db, mcpClient, logger, embeddingWorker } from "./lib/context";
 import { addLogSink, createFileSink } from "../mcp/utils/logger";
+import { reuseTelemetry } from "../mcp/utils/reuse-telemetry";
 import routes from "./routes";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -184,12 +185,14 @@ startServer();
 process.on("SIGINT", () => {
 	embeddingWorker.stop();
 	mcpClient.stop();
+	reuseTelemetry.flush(db);
 	db.close();
 	process.exit(0);
 });
 process.on("SIGTERM", () => {
 	embeddingWorker.stop();
 	mcpClient.stop();
+	reuseTelemetry.flush(db);
 	db.close();
 	process.exit(0);
 });

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -154,10 +154,6 @@ if (process.env.DASHBOARD_ENABLE_MCP === "true") {
 	mcpClient.start().catch((e) => logger.error("MCP Client failed", { error: e.message }));
 }
 
-// Start the embedding/KG outbox worker (TASK-013). Shares queue_jobs with the
-// MCP server; atomic claims + lease expiry keep the two workers safe.
-embeddingWorker.start();
-
 function startServer() {
 	const server = app.listen(PORT, HOST, () => {
 		const addr = server.address();

--- a/src/dashboard/services/codebase.service.ts
+++ b/src/dashboard/services/codebase.service.ts
@@ -146,7 +146,7 @@ export const CodebaseService = {
 		if (depth !== undefined) params.depth = depth;
 		if (includeSymbolCounts !== undefined) params.includeSymbolCounts = includeSymbolCounts;
 
-		const result = await handleCodebaseRead(injectOwner(params), db, noopVectors);
+		const result = await handleCodebaseRead(injectOwner({ ...params, json: true }), db, noopVectors);
 
 		if (!result.structuredContent) {
 			throw new ServiceError(500, "Unexpected empty response");
@@ -155,7 +155,7 @@ export const CodebaseService = {
 	},
 
 	async readFileSymbols(repo: string, filePath: string): Promise<unknown> {
-		const result = await handleCodebaseRead(injectOwner({ repo, filePath }), db, noopVectors);
+		const result = await handleCodebaseRead(injectOwner({ repo, filePath, json: true }), db, noopVectors);
 
 		if (!result.structuredContent) {
 			throw new ServiceError(500, "Unexpected empty response");
@@ -164,7 +164,7 @@ export const CodebaseService = {
 	},
 
 	async searchSymbols(query: Record<string, unknown>): Promise<unknown> {
-		const result = await handleCodebaseRead(injectOwner(query), db, noopVectors);
+		const result = await handleCodebaseRead(injectOwner({ ...query, json: true }), db, noopVectors);
 
 		if (!result.structuredContent) {
 			throw new ServiceError(500, "Unexpected empty response");
@@ -190,7 +190,7 @@ export const CodebaseService = {
 			);
 		}
 
-		const result = await handleCodebaseRead(injectOwner({ ...params, repoPath }), db, noopVectors);
+		const result = await handleCodebaseRead(injectOwner({ ...params, repoPath, json: true }), db, noopVectors);
 
 		if (!result.structuredContent) {
 			throw new ServiceError(500, "Unexpected empty response");
@@ -203,7 +203,7 @@ export const CodebaseService = {
 		if (repo !== undefined) params.repo = repo.trim();
 		if (includeReferences !== undefined) params.includeReferences = includeReferences;
 
-		const result = await handleCodebaseRead(injectOwner(params), db, noopVectors);
+		const result = await handleCodebaseRead(injectOwner({ ...params, json: true }), db, noopVectors);
 
 		if (!result.structuredContent) {
 			throw new ServiceError(500, "Unexpected empty response");

--- a/src/dashboard/services/kg.service.ts
+++ b/src/dashboard/services/kg.service.ts
@@ -44,17 +44,20 @@ export const KgService = {
 		return { items, total };
 	},
 
-	getEntity(name: string): {
+	getEntity(
+		name: string,
+		repo: string
+	): {
 		id: string;
 		entity: KgEntityRow;
 		relations: KgRelationRow[];
 		observations: KgObservationRow[];
 	} {
-		const entity = db.knowledgeGraph.getEntityByName(name);
+		const entity = db.knowledgeGraph.getEntityByName(name, repo);
 		if (!entity) throw new ServiceError(404, "Entity not found");
 
-		const relations = db.knowledgeGraph.getRelationsByName(name);
-		const observations = db.knowledgeGraph.getObservationsByName(name);
+		const relations = db.knowledgeGraph.getRelationsByName(name, repo);
+		const observations = db.knowledgeGraph.getObservationsByName(name, repo);
 
 		return { id: entity.name, entity, relations, observations };
 	},
@@ -129,10 +132,11 @@ export const KgService = {
 		name: string;
 		type?: string;
 		description?: string | null;
-		repo?: string;
+		repo: string;
 		owner?: string;
 	}): Promise<KgEntityRow> {
 		const { name, type, description, repo, owner } = attributes;
+		if (!repo) throw new ServiceError(400, "repo is required");
 
 		const now = new Date().toISOString();
 		// Invalidate cached graph payloads — dashboard-initiated mutations are
@@ -153,17 +157,17 @@ export const KgService = {
 			});
 		});
 
-		const entity = db.knowledgeGraph.getEntityByName(name);
+		const entity = db.knowledgeGraph.getEntityByName(name, repo || "");
 		return entity as KgEntityRow;
 	},
 
-	async deleteEntity(name: string): Promise<{ message: string; name: string }> {
+	async deleteEntity(name: string, repo: string): Promise<{ message: string; name: string }> {
 		clearKgGraphCache();
-		if (!db.knowledgeGraph.entityExists(name)) {
+		if (!db.knowledgeGraph.entityExists(name, repo)) {
 			throw new ServiceError(404, "Entity not found");
 		}
 
-		await db.withWrite(() => db.knowledgeGraph.deleteEntity(name));
+		await db.withWrite(() => db.knowledgeGraph.deleteEntity(name, repo));
 		return { message: "Deleted", name };
 	},
 
@@ -171,16 +175,17 @@ export const KgService = {
 		from_entity: string;
 		to_entity: string;
 		relation_type: string;
-		repo?: string;
+		repo: string;
 		owner?: string;
 	}): Promise<{ from_entity: string; to_entity: string; relation_type: string }> {
 		const { from_entity, to_entity, relation_type, repo, owner } = attributes;
 
-		if (!db.knowledgeGraph.entityExists(from_entity)) {
+		if (!repo) throw new ServiceError(400, "repo is required");
+		if (!db.knowledgeGraph.entityExists(from_entity, repo)) {
 			throw new ServiceError(400, `Source entity '${from_entity}' not found`);
 		}
 
-		if (!db.knowledgeGraph.entityExists(to_entity)) {
+		if (!db.knowledgeGraph.entityExists(to_entity, repo)) {
 			throw new ServiceError(400, `Target entity '${to_entity}' not found`);
 		}
 
@@ -208,9 +213,16 @@ export const KgService = {
 		return { from_entity, to_entity, relation_type };
 	},
 
-	async deleteRelation(from_entity: string, to_entity: string, relation_type: string): Promise<{ message: string }> {
+	async deleteRelation(
+		from_entity: string,
+		to_entity: string,
+		relation_type: string,
+		repo: string
+	): Promise<{ message: string }> {
 		clearKgGraphCache();
-		const result = await db.withWrite(() => db.knowledgeGraph.deleteRelation(from_entity, to_entity, relation_type));
+		const result = await db.withWrite(() =>
+			db.knowledgeGraph.deleteRelation(from_entity, to_entity, relation_type, repo)
+		);
 
 		if (result.changes === 0) {
 			throw new ServiceError(404, "Relation not found");

--- a/src/dashboard/services/system.service.ts
+++ b/src/dashboard/services/system.service.ts
@@ -120,6 +120,7 @@ export const SystemService = {
 			uptimeSeconds: Math.floor((Date.now() - startTime) / 1000),
 			pid: process.pid,
 			tools: snapshot.tools,
+			toolOutcomes: snapshot.toolOutcomes,
 			writeHandler: snapshot.writeHandler,
 			embedLatency: snapshot.embedLatency,
 			worker

--- a/src/dashboard/services/system.service.ts
+++ b/src/dashboard/services/system.service.ts
@@ -11,6 +11,7 @@ import { TOOL_DEFINITIONS } from "../../mcp/types/tool-definitions";
 import { listResources } from "../../mcp/resources";
 import { PROMPTS } from "../../mcp/prompts/registry";
 import { getRuntimeCapabilities, type RuntimeCapabilitySnapshot } from "../../mcp/runtime-capabilities";
+import { reuseTelemetry } from "../../mcp/utils/reuse-telemetry";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -110,9 +111,11 @@ export const SystemService = {
 	 * observational — no DB access, so callers skip the `db.refresh()`
 	 * lifecycle to keep high-frequency polling cheap.
 	 */
-	getMetrics(): Record<string, unknown> {
+	getMetrics(owner?: string, repo?: string, hours = 24): Record<string, unknown> {
 		const snapshot = metrics.snapshot();
 		const worker = embeddingWorker.getStats();
+		if (owner && repo && reuseTelemetry.isEnabled()) reuseTelemetry.flush(db);
+		const reuse = owner && repo && reuseTelemetry.isEnabled() ? db.reuseTelemetry.summarize(owner, repo, hours) : null;
 		return {
 			// NIT (OPT-OBS-01): explicit process marker so consumers can
 			// distinguish empty-by-design (tools/writeHandler are always empty
@@ -125,7 +128,8 @@ export const SystemService = {
 			toolOutcomes: snapshot.toolOutcomes,
 			writeHandler: snapshot.writeHandler,
 			embedLatency: snapshot.embedLatency,
-			worker
+			worker,
+			reuse
 		};
 	},
 

--- a/src/dashboard/services/system.service.ts
+++ b/src/dashboard/services/system.service.ts
@@ -10,6 +10,7 @@ import { getCachedRepoStats, setCachedRepoStats } from "./statsCache";
 import { TOOL_DEFINITIONS } from "../../mcp/types/tool-definitions";
 import { listResources } from "../../mcp/resources";
 import { PROMPTS } from "../../mcp/prompts/registry";
+import { getRuntimeCapabilities, type RuntimeCapabilitySnapshot } from "../../mcp/runtime-capabilities";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -66,6 +67,7 @@ export interface CapabilitySet {
 	tools: Array<Record<string, unknown>>;
 	resources: Array<Record<string, unknown>>;
 	prompts: Array<Record<string, unknown>>;
+	runtime: RuntimeCapabilitySnapshot;
 }
 
 export const SystemService = {
@@ -165,7 +167,7 @@ export const SystemService = {
 			id: prompt.name,
 			attributes: prompt
 		}));
-		return { tools, resources, prompts };
+		return { tools, resources, prompts, runtime: getRuntimeCapabilities().snapshot() };
 	},
 
 	/** Streams a full owner/repo export (memories → tasks → comments). */

--- a/src/dashboard/tests/controllers-kg.integration.test.ts
+++ b/src/dashboard/tests/controllers-kg.integration.test.ts
@@ -58,7 +58,7 @@ describe("Dashboard Controllers — KG API", () => {
 		});
 
 		it("GET /api/kg/entities/nonexist returns 404", async () => {
-			const res = await fetch(`${baseUrl}/api/kg/entities/nonexist`);
+			const res = await fetch(`${baseUrl}/api/kg/entities/nonexist?repo=test-repo`);
 			expect(res.status).toBe(404);
 			const body = (await res.json()) as Record<string, any>;
 			expect(body.errors[0].detail).toMatch(/not found/i);
@@ -344,8 +344,7 @@ describe("Dashboard Controllers — KG API", () => {
 
 		it("reflects a relation created via the API immediately (cache invalidation)", async () => {
 			const repo = "kg-cache-inval";
-			// entities.name is a GLOBAL PK — prefix names with the repo so
-			// tests in the same process can never collide (TASK-268).
+			// Keep descriptive names for this cache invalidation fixture.
 			seedEntity(repo, `${repo}-hub`);
 			seedEntity(repo, `${repo}-leaf-a`);
 			seedEntity(repo, `${repo}-leaf-b`);
@@ -394,7 +393,6 @@ describe("Dashboard Controllers — KG API", () => {
 		it("legacy pageSize window ships only subset-bounded edges (both endpoints in window)", async () => {
 			const repo = "kg-subset-window";
 			// 5 entities → legacy default pageSize 20 returns all of them.
-			// Names are repo-prefixed (entities.name is a GLOBAL PK).
 			seedEntity(repo, `${repo}-hub`);
 			seedEntity(repo, `${repo}-node-a`);
 			seedEntity(repo, `${repo}-node-b`);

--- a/src/dashboard/tests/lib/context.test.ts
+++ b/src/dashboard/tests/lib/context.test.ts
@@ -24,6 +24,7 @@ import fs from "node:fs";
 import type { MemoryEntry } from "../../../mcp/types/memory";
 import { db, embeddingWorker, logger, mcpClient, startTime, vectors } from "../../lib/context";
 import { SQLiteStore } from "../../../mcp/storage/sqlite";
+import { CapabilityAwareVectorStore } from "../../../mcp/storage/lazy-vectors";
 
 const mocks = vi.hoisted(() => {
 	// Force sqlite.ts's module-level `resolveDbPath()` (evaluated at import
@@ -35,6 +36,9 @@ const mocks = vi.hoisted(() => {
 	class RealVectorStoreMock {
 		readonly db: unknown;
 		readonly initialize: ReturnType<typeof vi.fn>;
+		readonly upsert = vi.fn();
+		readonly remove = vi.fn();
+		readonly search = vi.fn();
 		constructor(db: unknown) {
 			this.db = db;
 			this.initialize = vi.fn().mockResolvedValue(undefined);
@@ -99,18 +103,19 @@ describe("context module wiring (deps stubbed, store real)", () => {
 		expect(mcpClient).toBeInstanceOf(mocks.MCPClientMock);
 	});
 
-	it("constructs RealVectorStore with the store instance and initializes it once", () => {
-		const vectorStore = vectors as unknown as { db: unknown; initialize: MockedFn };
-		expect(vectors).toBeInstanceOf(mocks.RealVectorStoreMock);
+	it("wraps RealVectorStore and keeps full-profile startup backward compatible", () => {
+		expect(vectors).toBeInstanceOf(CapabilityAwareVectorStore);
+		const vectorStore = vectors.getInnerStore() as unknown as { db: unknown; initialize: MockedFn };
+		expect(vectorStore).toBeInstanceOf(mocks.RealVectorStoreMock);
 		expect(vectorStore.db).toBe(db);
 		expect(vectorStore.initialize).toHaveBeenCalledTimes(1);
 	});
 
-	it("constructs EmbeddingWorker with (db, vectors)", () => {
+	it("constructs EmbeddingWorker with the real vector store", () => {
 		const worker = embeddingWorker as unknown as { db: unknown; vectors: unknown };
 		expect(embeddingWorker).toBeInstanceOf(mocks.EmbeddingWorkerMock);
 		expect(worker.db).toBe(db);
-		expect(worker.vectors).toBe(vectors);
+		expect(worker.vectors).toBe(vectors.getInnerStore());
 	});
 
 	it("records a finite startTime", () => {

--- a/src/dashboard/tests/routes/kg.routes.integration.test.ts
+++ b/src/dashboard/tests/routes/kg.routes.integration.test.ts
@@ -208,6 +208,14 @@ describe("Knowledge-graph routes", () => {
 			await expectJsonApiError(`${baseUrl}/api/kg/relations`, 400, /repo/);
 		});
 
+		it("GET /api/kg/entities/:name without repo returns 400", async () => {
+			await expectJsonApiError(`${baseUrl}/api/kg/entities/example`, 400, /repo/);
+		});
+
+		it("DELETE /api/kg/entities/:name without repo returns 400", async () => {
+			await expectJsonApiError(`${baseUrl}/api/kg/entities/example`, 400, /repo/, { method: "DELETE" });
+		});
+
 		it("GET /api/kg/graph without repo returns 400", async () => {
 			await expectJsonApiError(`${baseUrl}/api/kg/graph`, 400, /repo/);
 		});
@@ -220,21 +228,21 @@ describe("Knowledge-graph routes", () => {
 			);
 		});
 
-		it("POST /api/kg/entities without name returns 400", async () => {
-			await expectJsonApiError(`${baseUrl}/api/kg/entities`, 400, /name is required/, POST_JSON);
+		it("POST /api/kg/entities without identity fields returns 400", async () => {
+			await expectJsonApiError(`${baseUrl}/api/kg/entities`, 400, /name and repo are required/, POST_JSON);
 		});
 
-		it("POST /api/kg/relations without from/to/relation_type returns 400", async () => {
+		it("POST /api/kg/relations without identity fields returns 400", async () => {
 			await expectJsonApiError(
 				`${baseUrl}/api/kg/relations`,
 				400,
-				/from_entity, to_entity, and relation_type/,
+				/from_entity, to_entity, relation_type, and repo/,
 				POST_JSON
 			);
 		});
 
-		it("DELETE /api/kg/relations without from/to/relation_type returns 400", async () => {
-			await expectJsonApiError(`${baseUrl}/api/kg/relations`, 400, /from_entity, to_entity, and relation_type/, {
+		it("DELETE /api/kg/relations without identity fields returns 400", async () => {
+			await expectJsonApiError(`${baseUrl}/api/kg/relations`, 400, /from_entity, to_entity, relation_type, and repo/, {
 				method: "DELETE",
 				headers: { "content-type": "application/json" },
 				body: "{}"
@@ -244,11 +252,11 @@ describe("Knowledge-graph routes", () => {
 
 	describe("404 handling", () => {
 		it("GET /api/kg/entities/:name with an unknown name returns 404", async () => {
-			await expectJsonApiError(`${baseUrl}/api/kg/entities/does-not-exist`, 404, /Entity not found/);
+			await expectJsonApiError(`${baseUrl}/api/kg/entities/does-not-exist?repo=route-test`, 404, /Entity not found/);
 		});
 
 		it("DELETE /api/kg/entities/:name with an unknown name returns 404", async () => {
-			await expectJsonApiError(`${baseUrl}/api/kg/entities/does-not-exist`, 404, /Entity not found/, {
+			await expectJsonApiError(`${baseUrl}/api/kg/entities/does-not-exist?repo=route-test`, 404, /Entity not found/, {
 				method: "DELETE"
 			});
 		});

--- a/src/dashboard/tests/services/codebase.service.test.ts
+++ b/src/dashboard/tests/services/codebase.service.test.ts
@@ -194,7 +194,7 @@ describe("CodebaseService read delegation", () => {
 
 		expect(result).toEqual({ tree: [] });
 		expect(mocks.handleCodebaseRead).toHaveBeenCalledWith(
-			{ repo: "acme/app", depth: "3", includeSymbolCounts: "true", owner: "acme" },
+			{ repo: "acme/app", depth: "3", includeSymbolCounts: "true", json: true, owner: "acme" },
 			mocks.db,
 			expect.any(Object)
 		);
@@ -216,7 +216,7 @@ describe("CodebaseService read delegation", () => {
 		await CodebaseService.traceSymbol("alpha", "  acme/app  ", "true");
 
 		expect(mocks.handleCodebaseRead).toHaveBeenCalledWith(
-			{ name: "alpha", repo: "acme/app", includeReferences: "true", owner: "acme" },
+			{ name: "alpha", repo: "acme/app", includeReferences: "true", json: true, owner: "acme" },
 			mocks.db,
 			expect.any(Object)
 		);

--- a/src/dashboard/tests/services/kg.service.test.ts
+++ b/src/dashboard/tests/services/kg.service.test.ts
@@ -162,7 +162,7 @@ describe("KgService.getEntity", () => {
 		vi.mocked(mocks.db.knowledgeGraph.getRelationsByName).mockReturnValue([makeRelation()]);
 		vi.mocked(mocks.db.knowledgeGraph.getObservationsByName).mockReturnValue([makeObservation()]);
 
-		const result = KgService.getEntity("User");
+		const result = KgService.getEntity("User", "acme/app");
 
 		expect(result.id).toBe("User");
 		expect(result.entity.name).toBe("User");
@@ -173,7 +173,7 @@ describe("KgService.getEntity", () => {
 	it("throws 404 when the entity does not exist", () => {
 		vi.mocked(mocks.db.knowledgeGraph.getEntityByName).mockReturnValue(undefined);
 
-		expect(() => KgService.getEntity("Ghost")).toThrowError(
+		expect(() => KgService.getEntity("Ghost", "acme/app")).toThrowError(
 			expect.objectContaining({ name: "ServiceError", status: 404, message: "Entity not found" })
 		);
 	});
@@ -260,7 +260,7 @@ describe("KgService.createEntity / deleteEntity", () => {
 		const created = makeEntity({ name: "Fresh", type: "unknown" });
 		vi.mocked(mocks.db.knowledgeGraph.getEntityByName).mockReturnValue(created);
 
-		const result = await KgService.createEntity({ name: "Fresh" });
+		const result = await KgService.createEntity({ name: "Fresh", repo: "acme/app" });
 
 		expect(result).toBe(created);
 		expect(mocks.db.knowledgeGraph.createEntity).toHaveBeenCalledWith(
@@ -268,7 +268,7 @@ describe("KgService.createEntity / deleteEntity", () => {
 				name: "Fresh",
 				type: "unknown",
 				description: null,
-				repo: "",
+				repo: "acme/app",
 				owner: ""
 			})
 		);
@@ -297,7 +297,7 @@ describe("KgService.createEntity / deleteEntity", () => {
 		vi.mocked(mocks.db.knowledgeGraph.listGraphNodes).mockReturnValue([makeEntity()]);
 		KgService.listGraph("acme/app", 10, 0, true);
 
-		await KgService.createEntity({ name: "Fresh" });
+		await KgService.createEntity({ name: "Fresh", repo: "acme/app" });
 
 		// Cache cleared ⇒ next listGraph re-queries the DB.
 		KgService.listGraph("acme/app", 10, 0, true);
@@ -307,16 +307,16 @@ describe("KgService.createEntity / deleteEntity", () => {
 	it("deletes an existing entity and returns the ack", async () => {
 		vi.mocked(mocks.db.knowledgeGraph.entityExists).mockReturnValue(true);
 
-		const result = await KgService.deleteEntity("User");
+		const result = await KgService.deleteEntity("User", "acme/app");
 
 		expect(result).toEqual({ message: "Deleted", name: "User" });
-		expect(mocks.db.knowledgeGraph.deleteEntity).toHaveBeenCalledWith("User");
+		expect(mocks.db.knowledgeGraph.deleteEntity).toHaveBeenCalledWith("User", "acme/app");
 	});
 
 	it("throws 404 when deleting an unknown entity", async () => {
 		vi.mocked(mocks.db.knowledgeGraph.entityExists).mockReturnValue(false);
 
-		await expect(KgService.deleteEntity("Ghost")).rejects.toMatchObject({
+		await expect(KgService.deleteEntity("Ghost", "acme/app")).rejects.toMatchObject({
 			name: "ServiceError",
 			status: 404,
 			message: "Entity not found"
@@ -325,13 +325,14 @@ describe("KgService.createEntity / deleteEntity", () => {
 });
 
 describe("KgService.createRelation", () => {
-	it("creates a relation when both endpoints exist (defaults repo/owner to empty)", async () => {
+	it("creates a relation within the requested repository", async () => {
 		vi.mocked(mocks.db.knowledgeGraph.entityExists).mockReturnValue(true);
 
 		const result = await KgService.createRelation({
 			from_entity: "User",
 			to_entity: "Order",
-			relation_type: "creates"
+			relation_type: "creates",
+			repo: "acme/app"
 		});
 
 		expect(result).toEqual({ from_entity: "User", to_entity: "Order", relation_type: "creates" });
@@ -340,7 +341,7 @@ describe("KgService.createRelation", () => {
 				from_entity: "User",
 				to_entity: "Order",
 				relation_type: "creates",
-				repo: "",
+				repo: "acme/app",
 				owner: ""
 			})
 		);
@@ -350,7 +351,7 @@ describe("KgService.createRelation", () => {
 		vi.mocked(mocks.db.knowledgeGraph.entityExists).mockImplementation((name: string) => name !== "User");
 
 		await expect(
-			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates" })
+			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates", repo: "acme/app" })
 		).rejects.toMatchObject({
 			name: "ServiceError",
 			status: 400,
@@ -363,7 +364,7 @@ describe("KgService.createRelation", () => {
 		vi.mocked(mocks.db.knowledgeGraph.entityExists).mockImplementation((name: string) => name === "User");
 
 		await expect(
-			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates" })
+			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates", repo: "acme/app" })
 		).rejects.toMatchObject({
 			name: "ServiceError",
 			status: 400,
@@ -378,7 +379,7 @@ describe("KgService.createRelation", () => {
 		});
 
 		await expect(
-			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates" })
+			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates", repo: "acme/app" })
 		).rejects.toMatchObject({
 			name: "ServiceError",
 			status: 409,
@@ -393,7 +394,7 @@ describe("KgService.createRelation", () => {
 		});
 
 		await expect(
-			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates" })
+			KgService.createRelation({ from_entity: "User", to_entity: "Order", relation_type: "creates", repo: "acme/app" })
 		).rejects.toThrow("disk full");
 	});
 });
@@ -402,16 +403,16 @@ describe("KgService.deleteRelation / deleteObservation", () => {
 	it("deletes an existing relation and returns the ack", async () => {
 		vi.mocked(mocks.db.knowledgeGraph.deleteRelation).mockReturnValue({ changes: 1 });
 
-		const result = await KgService.deleteRelation("User", "Order", "creates");
+		const result = await KgService.deleteRelation("User", "Order", "creates", "acme/app");
 
 		expect(result).toEqual({ message: "Deleted" });
-		expect(mocks.db.knowledgeGraph.deleteRelation).toHaveBeenCalledWith("User", "Order", "creates");
+		expect(mocks.db.knowledgeGraph.deleteRelation).toHaveBeenCalledWith("User", "Order", "creates", "acme/app");
 	});
 
 	it("throws 404 when the relation matched zero rows", async () => {
 		vi.mocked(mocks.db.knowledgeGraph.deleteRelation).mockReturnValue({ changes: 0 });
 
-		await expect(KgService.deleteRelation("User", "Order", "creates")).rejects.toMatchObject({
+		await expect(KgService.deleteRelation("User", "Order", "creates", "acme/app")).rejects.toMatchObject({
 			name: "ServiceError",
 			status: 404,
 			message: "Relation not found"

--- a/src/dashboard/tests/services/system.service.test.ts
+++ b/src/dashboard/tests/services/system.service.test.ts
@@ -191,6 +191,7 @@ describe("SystemService.getMetrics", () => {
 		expect(metrics.uptimeSeconds).toEqual(expect.any(Number));
 		expect(metrics.pid).toBe(process.pid);
 		expect(metrics.tools).toBeDefined();
+		expect(metrics.toolOutcomes).toBeDefined();
 		expect(metrics.writeHandler).toBeDefined();
 		expect(metrics.embedLatency).toBeDefined();
 		expect(metrics.worker).toEqual({ pending: 5, running: true });

--- a/src/dashboard/tests/services/system.service.test.ts
+++ b/src/dashboard/tests/services/system.service.test.ts
@@ -24,7 +24,8 @@ const mocks = vi.hoisted(() => {
 		actions: { getRecentActions: vi.fn() },
 		memories: { getAllMemoriesWithStats: vi.fn() },
 		tasks: { getTasksByRepo: vi.fn() },
-		taskComments: { getAllTaskCommentsByRepo: vi.fn() }
+		taskComments: { getAllTaskCommentsByRepo: vi.fn() },
+		reuseTelemetry: { summarize: vi.fn() }
 	};
 	return {
 		db,
@@ -192,6 +193,14 @@ describe("SystemService.getStats", () => {
 });
 
 describe("SystemService.getMetrics", () => {
+	it("includes a repo/time-window reuse summary when scoped", () => {
+		vi.mocked(mocks.embeddingWorker.getStats).mockReturnValue({ pending: 0, running: true });
+		vi.mocked(mocks.db.reuseTelemetry.summarize).mockReturnValue({ from: "from", to: "to", metrics: {} });
+		const result = SystemService.getMetrics("owner", "repo", 48);
+		expect(mocks.db.reuseTelemetry.summarize).toHaveBeenCalledWith("owner", "repo", 48);
+		expect(result.reuse).toEqual({ from: "from", to: "to", metrics: {} });
+	});
+
 	it("merges the runtime snapshot with the embedding worker stats", () => {
 		vi.mocked(mocks.embeddingWorker.getStats).mockReturnValue({ pending: 5, running: true });
 
@@ -205,6 +214,7 @@ describe("SystemService.getMetrics", () => {
 		expect(metrics.writeHandler).toBeDefined();
 		expect(metrics.embedLatency).toBeDefined();
 		expect(metrics.worker).toEqual({ pending: 5, running: true });
+		expect(metrics.reuse).toBeNull();
 	});
 });
 

--- a/src/dashboard/tests/services/system.service.test.ts
+++ b/src/dashboard/tests/services/system.service.test.ts
@@ -75,6 +75,16 @@ vi.mock("../../../mcp/resources", () => ({
 	}))
 }));
 
+vi.mock("../../../mcp/runtime-capabilities", () => ({
+	getRuntimeCapabilities: () => ({
+		snapshot: () => ({
+			profile: "full",
+			capabilities: { semantic: { state: "ready" } },
+			footprint: { rss_bytes: 1024, heap_used_bytes: 512 }
+		})
+	})
+}));
+
 vi.mock("../../../mcp/prompts/registry", () => ({
 	PROMPTS: {
 		greeter: { name: "greeter", description: "Greets the user" },
@@ -263,6 +273,11 @@ describe("SystemService.getCapabilities", () => {
 
 		expect(caps.prompts.map((p) => p.id)).toEqual(["greeter", "fallback"]);
 		expect(caps.prompts[0]).toMatchObject({ type: "prompt", id: "greeter" });
+		expect(caps.runtime).toMatchObject({
+			profile: "full",
+			capabilities: { semantic: { state: "ready" } },
+			footprint: { rss_bytes: 1024, heap_used_bytes: 512 }
+		});
 	});
 });
 

--- a/src/dashboard/ui/src/components/KGEntityDrawer.svelte
+++ b/src/dashboard/ui/src/components/KGEntityDrawer.svelte
@@ -5,11 +5,12 @@
 
 	export interface KGEntityDrawerProps {
 		entityName?: string;
+		repo: string;
 		onclose?: () => void;
 		onnavigate?: (name: string) => void;
 	}
 
-	let { entityName = "", onclose, onnavigate }: KGEntityDrawerProps = $props();
+	let { entityName = "", repo, onclose, onnavigate }: KGEntityDrawerProps = $props();
 
 	let show = $state(false);
 	let loading = $state(false);
@@ -25,11 +26,12 @@
 		created_at: string;
 	}> = $state([]);
 	let error = $state("");
-	let prevName = $state("");
+	let prevIdentity = $state("");
 
 	$effect(() => {
-		if (entityName && entityName !== prevName) {
-			prevName = entityName;
+		const identity = `${repo}\u0000${entityName}`;
+		if (entityName && identity !== prevIdentity) {
+			prevIdentity = identity;
 			void loadDetail(entityName);
 		} else if (!entityName) {
 			show = false;
@@ -44,7 +46,7 @@
 		relations = [];
 		observations = [];
 		try {
-			const data = await api.kgEntityDetail(name);
+			const data = await api.kgEntityDetail(name, repo);
 			entity = (data.entity as KgEntityDetail) || null;
 			relations = (data.relations || []) as Array<{
 				from_entity: string;

--- a/src/dashboard/ui/src/components/KGGraph.svelte
+++ b/src/dashboard/ui/src/components/KGGraph.svelte
@@ -176,13 +176,14 @@
 		if (!deleteTarget) return;
 		try {
 			if (deleteTarget.type === "node") {
-				await api.kgDeleteEntity(deleteTarget.name);
+				await api.kgDeleteEntity(deleteTarget.name, repo);
 			} else if (deleteTarget.type === "edge") {
 				const e = deleteTarget.edge;
 				await api.kgDeleteRelation({
 					from_entity: e.source,
 					to_entity: e.target,
-					relation_type: e.relation_type
+					relation_type: e.relation_type,
+					repo
 				});
 			}
 			showDeleteConfirm = false;
@@ -306,6 +307,7 @@
 		/>
 		<KGEntityDrawer
 			entityName={detailEntityName}
+			{repo}
 			onclose={() => {
 				detailEntityName = "";
 				graphState.selectedNode = null;

--- a/src/dashboard/ui/src/lib/api/resources/kg.ts
+++ b/src/dashboard/ui/src/lib/api/resources/kg.ts
@@ -29,9 +29,9 @@ export const kgApi = {
 		);
 	},
 
-	kgEntityDetail: (name: string) =>
+	kgEntityDetail: (name: string, repo: string) =>
 		apiFetch<{ entity: Record<string, unknown>; relations: unknown[]; observations: unknown[] }>(
-			`/api/kg/entities/${encodeURIComponent(name)}`
+			`/api/kg/entities/${encodeURIComponent(name)}?repo=${encodeURIComponent(repo)}`
 		),
 
 	kgEntities: (repo: string, params?: { type?: string; search?: string; page?: number; pageSize?: number }) => {
@@ -50,8 +50,10 @@ export const kgApi = {
 			body: JSON.stringify(body)
 		}),
 
-	kgDeleteEntity: (name: string) =>
-		apiFetch<{ success: boolean }>(`/api/kg/entities/${encodeURIComponent(name)}`, { method: "DELETE" }),
+	kgDeleteEntity: (name: string, repo: string) =>
+		apiFetch<{ success: boolean }>(`/api/kg/entities/${encodeURIComponent(name)}?repo=${encodeURIComponent(repo)}`, {
+			method: "DELETE"
+		}),
 
 	kgCreateRelation: (body: { from_entity: string; to_entity: string; relation_type: string; repo: string }) =>
 		apiFetch<{ success: boolean }>("/api/kg/relations", {
@@ -60,7 +62,7 @@ export const kgApi = {
 			body: JSON.stringify(body)
 		}),
 
-	kgDeleteRelation: (body: { from_entity: string; to_entity: string; relation_type: string }) =>
+	kgDeleteRelation: (body: { from_entity: string; to_entity: string; relation_type: string; repo: string }) =>
 		apiFetch<{ success: boolean }>("/api/kg/relations", {
 			method: "DELETE",
 			headers: { "Content-Type": "application/json" },

--- a/src/mcp/codebase-index/parser/singleton.ts
+++ b/src/mcp/codebase-index/parser/singleton.ts
@@ -1,0 +1,15 @@
+import type { ParserPool } from "./language-visitor";
+import { TreeSitterParserPool } from "./parser-pool";
+
+let parserPool: ParserPool | null = null;
+
+/** Process-wide parser pool shared by startup, watcher, tool, and dashboard calls. */
+export function getCodebaseParserPool(): ParserPool {
+	parserPool ??= new TreeSitterParserPool();
+	return parserPool;
+}
+
+/** Test-only reset; production holds one pool for the process lifetime. */
+export function resetCodebaseParserPool(): void {
+	parserPool = null;
+}

--- a/src/mcp/codebase-index/services/indexing-writer.ts
+++ b/src/mcp/codebase-index/services/indexing-writer.ts
@@ -112,6 +112,7 @@ export async function applyRenames(base: WriteBaseContext, renameMap: Map<string
 				db.codebaseFiles.transferFile(repo, oldPath, newPath);
 				db.codebaseSymbols.transferSymbolsFilePath(repo, oldPath, newPath);
 				db.codebaseReferences.transferReferencesFilePath(repo, oldPath, newPath);
+				db.explorationObservations.transferEvidencePath(repo, oldPath, newPath);
 
 				// Purge the old-path queue job — the file record no longer
 				// exists under this entity id, so any pending job would re-run
@@ -160,6 +161,7 @@ export async function applyRenames(base: WriteBaseContext, renameMap: Map<string
 				if (symbols.length > 0 || refs.length > 0) {
 					enqueueCodebaseSymbols(db, repo, newPath, symbols, refs);
 				}
+				db.explorationObservations.refreshForFiles(repo, [newPath]);
 			}
 		});
 	}, "rename-transfer");
@@ -270,6 +272,10 @@ export async function writeParseBatch(
 					// still reverts the whole batch.
 					db.db
 						.transaction(() => {
+							// Mark every affected observation stale first. The bounded
+							// structural refresh below can promote unchanged evidence back to
+							// valid; rows beyond its cap remain conservatively stale.
+							db.explorationObservations.markFilesStale(repo, [...reindexedPaths], "file_reindexed");
 							for (const fp of reindexedPaths) {
 								db.codebaseSymbols.deleteSymbolsByFile(repo, fp);
 							}
@@ -325,6 +331,7 @@ export async function writeParseBatch(
 									enqueueCodebaseSymbols(db, repo, fp, symbols ?? [], refs ?? []);
 								}
 							}
+							db.explorationObservations.refreshForFiles(repo, [...reindexedPaths]);
 						})
 						.immediate();
 				});
@@ -384,6 +391,7 @@ export async function cleanStaleFiles(base: WriteBaseContext, stalePaths: Set<st
 					const chunk = paths.slice(start, start + CLEANUP_TXN_CHUNK);
 					db.db
 						.transaction(() => {
+							db.explorationObservations.markFilesStale(repo, chunk, "file_deleted");
 							for (const fp of chunk) {
 								db.codebaseSymbols.deleteSymbolsByFile(repo, fp);
 								db.codebaseReferences.deleteReferencesByFile(repo, fp);

--- a/src/mcp/codebase-index/services/parse-pipeline/enrich-parse.ts
+++ b/src/mcp/codebase-index/services/parse-pipeline/enrich-parse.ts
@@ -72,7 +72,7 @@ export async function enrichParsedOutcome(
 	const { map, enriched } = await semanticPassFor(ctx, outcome, symbols);
 	const resolved: ResolvedSymbols = { symbols, semanticMap: map.size > 0 ? map : null, semanticEnriched: enriched };
 
-	const symbolRows = symbols.map((sym) => symbolRow(sym, ctx.repo, outcome.plan.filePath));
+	const symbolRows = symbols.map((sym) => symbolRow(sym, ctx.repo, outcome.plan.filePath, outcome.content));
 	const referenceInserts = buildReferenceRows(ctx, outcome);
 	return {
 		resolved,

--- a/src/mcp/codebase-index/services/parse-pipeline/row-mappers.ts
+++ b/src/mcp/codebase-index/services/parse-pipeline/row-mappers.ts
@@ -11,6 +11,7 @@ import type { ParsedReference } from "../../parser/language-visitor";
 import type { CodebaseFileInsert, CodebaseSymbolInsert, CodebaseReferenceInsert } from "../../../types";
 import type { ParseTask } from "./constants";
 import type { SymbolWithSemantic } from "./types";
+import { fingerprintSourceRange } from "../../../utils/source-fingerprint";
 
 /** Build a canonical {@link CodebaseReferenceInsert} from a visitor reference. */
 export function referenceInsert(ref: ParsedReference, filePath: string, repo: string): CodebaseReferenceInsert {
@@ -67,7 +68,12 @@ export function referenceInsertFromRow(row: {
  * replaced atomically per file by the indexing writer (delete-by-file +
  * bulk-insert in one txn), so the entity honors the pre-assigned id.
  */
-export function symbolRow(sym: SymbolWithSemantic, repo: string, filePath: string): CodebaseSymbolInsert {
+export function symbolRow(
+	sym: SymbolWithSemantic,
+	repo: string,
+	filePath: string,
+	content: string
+): CodebaseSymbolInsert {
 	return {
 		id: sym.id,
 		repo,
@@ -85,7 +91,8 @@ export function symbolRow(sym: SymbolWithSemantic, repo: string, filePath: strin
 		parent_symbol_id: sym.resolvedParentSymbolId,
 		semantic_signature: sym.semantic?.semanticSignature ?? null,
 		semantic_source: sym.semantic?.semanticSource ?? null,
-		semantic_updated_at: sym.semanticUpdatedAt
+		semantic_updated_at: sym.semanticUpdatedAt,
+		source_fingerprint: fingerprintSourceRange(content, sym.startLine, sym.endLine)
 	};
 }
 

--- a/src/mcp/entities/codebase-symbol.ts
+++ b/src/mcp/entities/codebase-symbol.ts
@@ -21,12 +21,12 @@ export class CodebaseSymbolEntity extends BaseEntity {
 				INSERT INTO codebase_symbols (
 					id, repo, file_path, name, kind, exported, default_export,
 					start_line, start_col, end_line, end_col, signature, doc_comment,
-					parent_symbol_id, semantic_signature, semantic_source, semantic_updated_at,
+					parent_symbol_id, semantic_signature, semantic_source, semantic_updated_at, source_fingerprint,
 					created_at, updated_at
 				) VALUES (
 					?, ?, ?, ?, ?, ?, ?,
 					?, ?, ?, ?, ?, ?,
-					?, ?, ?, ?,
+					?, ?, ?, ?, ?,
 					?, ?
 				)
 			`);
@@ -54,6 +54,7 @@ export class CodebaseSymbolEntity extends BaseEntity {
 					sym.semantic_signature ?? null,
 					sym.semantic_source ?? null,
 					sym.semantic_updated_at ?? null,
+					sym.source_fingerprint ?? null,
 					now,
 					now
 				);

--- a/src/mcp/entities/exploration-observation.ts
+++ b/src/mcp/entities/exploration-observation.ts
@@ -1,11 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 import { BaseEntity } from "../storage/base";
+import { fingerprintSymbol } from "../utils/source-fingerprint";
 import type {
 	ExplorationEvidence,
 	ExplorationEvidenceInput,
 	ExplorationObservation,
 	ExplorationObservationInput,
-	ExplorationObservationRow
+	ExplorationObservationRow,
+	CodebaseSymbol
 } from "../types";
 
 interface EvidenceRow {
@@ -15,6 +17,10 @@ interface EvidenceRow {
 	symbol_id: string | null;
 	start_line: number | null;
 	end_line: number | null;
+	file_checksum: string | null;
+	symbol_fingerprint: string | null;
+	indexed_at: string | null;
+	commit_sha: string | null;
 	created_at: string;
 }
 
@@ -26,8 +32,16 @@ export interface ObservationQuery {
 	file_path?: string;
 	symbol_id?: string;
 	min_confidence?: number;
+	include_stale?: boolean;
 	limit?: number;
 	offset?: number;
+}
+
+interface EvidenceFingerprint {
+	fileChecksum: string | null;
+	symbolFingerprint: string | null;
+	indexedAt: string | null;
+	freshness: "valid" | "unverifiable";
 }
 
 export interface ObservationWriteResult {
@@ -67,6 +81,39 @@ export class ExplorationObservationEntity extends BaseEntity {
 		return this.transaction(() => inputs.map((input) => this.upsert(owner, repo, input, updateId)));
 	}
 
+	private fingerprintEvidence(repo: string, evidence: ExplorationEvidenceInput): EvidenceFingerprint {
+		const file = this.get<{ checksum: string | null; last_indexed_at: string | null }>(
+			"SELECT checksum, last_indexed_at FROM codebase_files WHERE repo = ? AND file_path = ?",
+			[repo, evidence.file_path]
+		);
+		if (!file?.checksum) {
+			return {
+				fileChecksum: null,
+				symbolFingerprint: null,
+				indexedAt: null,
+				freshness: "unverifiable"
+			};
+		}
+		if (!evidence.symbol_id) {
+			return {
+				fileChecksum: file.checksum,
+				symbolFingerprint: null,
+				indexedAt: file.last_indexed_at,
+				freshness: "valid"
+			};
+		}
+		const symbol = this.get<CodebaseSymbol>(
+			"SELECT * FROM codebase_symbols WHERE id = ? AND repo = ? AND file_path = ?",
+			[evidence.symbol_id, repo, evidence.file_path]
+		);
+		return {
+			fileChecksum: file.checksum,
+			symbolFingerprint: symbol ? fingerprintSymbol(symbol) : null,
+			indexedAt: file.last_indexed_at,
+			freshness: symbol ? "valid" : "unverifiable"
+		};
+	}
+
 	private upsert(
 		owner: string,
 		repo: string,
@@ -85,6 +132,8 @@ export class ExplorationObservationEntity extends BaseEntity {
 				);
 
 		const now = new Date().toISOString();
+		const fingerprints = input.evidence.map((evidence) => this.fingerprintEvidence(repo, evidence));
+		const freshness = fingerprints.every((fingerprint) => fingerprint.freshness === "valid") ? "valid" : "unverifiable";
 		if (existing) {
 			// A hash match without an explicit id is an idempotent retry: return the
 			// existing row byte-for-byte instead of churning updated_at/evidence.
@@ -93,7 +142,8 @@ export class ExplorationObservationEntity extends BaseEntity {
 			}
 			this.run(
 				`UPDATE exploration_observations
-				 SET subject = ?, fact = ?, confidence = ?, task_id = ?, agent = ?, identity_hash = ?, updated_at = ?
+				 SET subject = ?, fact = ?, confidence = ?, task_id = ?, agent = ?, identity_hash = ?, freshness = ?,
+				     stale_reason = ?, last_verified_at = ?, updated_at = ?
 				 WHERE id = ? AND owner = ? AND repo = ?`,
 				[
 					input.subject,
@@ -102,13 +152,17 @@ export class ExplorationObservationEntity extends BaseEntity {
 					input.task_id ?? null,
 					input.agent ?? null,
 					identityHash,
+					freshness,
+					freshness === "valid" ? null : "source_not_indexed",
+					freshness === "valid" ? now : null,
 					now,
 					existing.id,
 					owner,
 					repo
 				]
 			);
-			this.replaceEvidence(existing.id, input.evidence, now);
+			this.replaceEvidence(existing.id, input.evidence, fingerprints, now);
+			if (input.supersedes_id) this.markSuperseded(owner, repo, input.supersedes_id, existing.id, now);
 			return { observation: this.getById(owner, repo, existing.id, true)!, created: false };
 		}
 
@@ -116,8 +170,8 @@ export class ExplorationObservationEntity extends BaseEntity {
 		const id = randomUUID();
 		this.run(
 			`INSERT INTO exploration_observations
-			 (id, owner, repo, subject, fact, confidence, task_id, agent, identity_hash, freshness, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'valid', ?, ?)`,
+			 (id, owner, repo, subject, fact, confidence, task_id, agent, identity_hash, freshness, stale_reason, last_verified_at, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
 				id,
 				owner,
@@ -128,22 +182,34 @@ export class ExplorationObservationEntity extends BaseEntity {
 				input.task_id ?? null,
 				input.agent ?? null,
 				identityHash,
+				freshness,
+				freshness === "valid" ? null : "source_not_indexed",
+				freshness === "valid" ? now : null,
 				now,
 				now
 			]
 		);
-		this.replaceEvidence(id, input.evidence, now);
+		this.replaceEvidence(id, input.evidence, fingerprints, now);
+		if (input.supersedes_id) this.markSuperseded(owner, repo, input.supersedes_id, id, now);
 		return { observation: this.getById(owner, repo, id, true)!, created: true };
 	}
 
-	private replaceEvidence(observationId: string, evidence: ExplorationEvidenceInput[], now: string): void {
+	private replaceEvidence(
+		observationId: string,
+		evidence: ExplorationEvidenceInput[],
+		fingerprints: EvidenceFingerprint[],
+		now: string
+	): void {
 		this.run("DELETE FROM exploration_evidence WHERE observation_id = ?", [observationId]);
-		const unique = new Map(evidence.map((item) => [evidenceIdentity(item), item]));
-		for (const item of unique.values()) {
+		const unique = new Map(
+			evidence.map((item, index) => [evidenceIdentity(item), { item, fingerprint: fingerprints[index]! }])
+		);
+		for (const { item, fingerprint } of unique.values()) {
 			this.run(
 				`INSERT INTO exploration_evidence
-				 (id, observation_id, file_path, symbol_id, start_line, end_line, created_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				 (id, observation_id, file_path, symbol_id, start_line, end_line,
+				  file_checksum, symbol_fingerprint, indexed_at, commit_sha, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				[
 					randomUUID(),
 					observationId,
@@ -151,10 +217,156 @@ export class ExplorationObservationEntity extends BaseEntity {
 					item.symbol_id ?? null,
 					item.start_line ?? null,
 					item.end_line ?? null,
+					fingerprint.fileChecksum,
+					fingerprint.symbolFingerprint,
+					fingerprint.indexedAt,
+					item.commit_sha ?? null,
 					now
 				]
 			);
 		}
+	}
+
+	private markSuperseded(owner: string, repo: string, oldId: string, newId: string, now: string): void {
+		if (oldId === newId) throw new Error("An observation cannot supersede itself");
+		const result = this.run(
+			`UPDATE exploration_observations
+			 SET freshness = 'stale', stale_reason = 'superseded', superseded_by = ?, updated_at = ?
+			 WHERE id = ? AND owner = ? AND repo = ?`,
+			[newId, now, oldId, owner, repo]
+		);
+		if (result.changes === 0) throw new Error(`Superseded exploration observation not found: ${oldId}`);
+	}
+
+	markFilesStale(repo: string, filePaths: string[], reason: string): number {
+		if (filePaths.length === 0) return 0;
+		const placeholders = filePaths.map(() => "?").join(",");
+		return this.run(
+			`UPDATE exploration_observations
+			 SET freshness = 'stale', stale_reason = ?, updated_at = ?
+			 WHERE repo = ? AND id IN (
+				SELECT DISTINCT observation_id FROM exploration_evidence WHERE file_path IN (${placeholders})
+			 )`,
+			[reason, new Date().toISOString(), repo, ...filePaths]
+		).changes;
+	}
+
+	transferEvidencePath(repo: string, oldPath: string, newPath: string): number {
+		return this.run(
+			`UPDATE exploration_evidence SET file_path = ?
+			 WHERE file_path = ? AND observation_id IN (
+				SELECT id FROM exploration_observations WHERE repo = ?
+			 )`,
+			[newPath, oldPath, repo]
+		).changes;
+	}
+
+	refreshByIds(owner: string, repo: string, ids: string[]): ExplorationObservation[] {
+		const uniqueIds = [...new Set(ids)].slice(0, 100);
+		return this.transaction(() =>
+			uniqueIds.flatMap((id) => {
+				const observation = this.getById(owner, repo, id, true);
+				return observation ? [this.refreshOne(observation)] : [];
+			})
+		);
+	}
+
+	refreshForFiles(repo: string, filePaths: string[], limit = 1000): number {
+		if (filePaths.length === 0) return 0;
+		const placeholders = filePaths.map(() => "?").join(",");
+		const rows = this.all<{ owner: string; id: string }>(
+			`SELECT DISTINCT o.owner, o.id
+			 FROM exploration_observations o
+			 JOIN exploration_evidence e ON e.observation_id = o.id
+			 WHERE o.repo = ? AND e.file_path IN (${placeholders})
+			 ORDER BY o.id LIMIT ?`,
+			[repo, ...filePaths, limit]
+		);
+		this.transaction(() => {
+			for (const row of rows) {
+				const observation = this.getById(row.owner, repo, row.id, true);
+				if (observation) this.refreshOne(observation);
+			}
+		});
+		return rows.length;
+	}
+
+	private refreshOne(observation: ExplorationObservation): ExplorationObservation {
+		const evidence = observation.evidence ?? [];
+		let state: "valid" | "stale" | "unverifiable" = "valid";
+		let reason: string | null = null;
+		const setState = (next: "stale" | "unverifiable", nextReason: string): void => {
+			if (state === "stale" || (state === "unverifiable" && next === "unverifiable")) return;
+			state = next;
+			reason = nextReason;
+		};
+		const now = new Date().toISOString();
+		if (observation.superseded_by) return observation;
+		for (const item of evidence) {
+			const file = this.get<{ checksum: string | null; last_indexed_at: string | null }>(
+				"SELECT checksum, last_indexed_at FROM codebase_files WHERE repo = ? AND file_path = ?",
+				[observation.repo, item.file_path]
+			);
+			if (!file?.checksum) {
+				setState("unverifiable", "source_not_indexed");
+				continue;
+			}
+			if (!item.symbol_id) {
+				if (item.file_checksum && item.file_checksum !== file.checksum) {
+					setState("stale", "file_changed");
+				} else {
+					this.updateEvidenceFingerprint(item.id, file.checksum, null, null, file.last_indexed_at);
+				}
+				continue;
+			}
+			const symbols = this.all<CodebaseSymbol>(
+				"SELECT * FROM codebase_symbols WHERE repo = ? AND file_path = ? ORDER BY start_line",
+				[observation.repo, item.file_path]
+			);
+			const matched = symbols.find((symbol) => fingerprintSymbol(symbol) === item.symbol_fingerprint);
+			const current = matched ?? symbols[0];
+			if (!current || (item.symbol_fingerprint && !matched)) {
+				setState("stale", current ? "symbol_changed" : "symbol_deleted");
+				continue;
+			}
+			this.updateEvidenceFingerprint(
+				item.id,
+				file.checksum,
+				current.id,
+				fingerprintSymbol(current),
+				file.last_indexed_at
+			);
+		}
+		this.run(
+			`UPDATE exploration_observations
+			 SET freshness = ?, stale_reason = ?, last_verified_at = ?, updated_at = ?
+			 WHERE id = ? AND owner = ? AND repo = ?`,
+			[
+				state,
+				reason,
+				state === "valid" ? now : observation.last_verified_at,
+				now,
+				observation.id,
+				observation.owner,
+				observation.repo
+			]
+		);
+		return this.getById(observation.owner, observation.repo, observation.id, true)!;
+	}
+
+	private updateEvidenceFingerprint(
+		id: string,
+		fileChecksum: string,
+		symbolId: string | null,
+		fingerprint: string | null,
+		indexedAt: string | null
+	): void {
+		this.run(
+			`UPDATE exploration_evidence
+			 SET file_checksum = ?, symbol_id = ?, symbol_fingerprint = ?, indexed_at = ?
+			 WHERE id = ?`,
+			[fileChecksum, symbolId, fingerprint, indexedAt, id]
+		);
 	}
 
 	getById(owner: string, repo: string, id: string, hydrateEvidence = false): ExplorationObservation | null {
@@ -172,6 +384,7 @@ export class ExplorationObservationEntity extends BaseEntity {
 	list(query: ObservationQuery, hydrateEvidence = false): ExplorationObservation[] {
 		const conditions = ["o.owner = ?", "o.repo = ?", "o.confidence >= ?"];
 		const values: unknown[] = [query.owner, query.repo, query.min_confidence ?? 0];
+		if (!query.include_stale) conditions.push("o.freshness = 'valid' AND o.superseded_by IS NULL");
 		if (query.subject) {
 			conditions.push("o.subject LIKE ?");
 			values.push(`%${query.subject}%`);
@@ -210,7 +423,8 @@ export class ExplorationObservationEntity extends BaseEntity {
 		const observation: ExplorationObservation = { ...row, evidence_count: Number(row.evidence_count ?? 0) };
 		if (includeEvidence) {
 			observation.evidence = this.all<EvidenceRow>(
-				`SELECT id, observation_id, file_path, symbol_id, start_line, end_line, created_at
+				`SELECT id, observation_id, file_path, symbol_id, start_line, end_line,
+				        file_checksum, symbol_fingerprint, indexed_at, commit_sha, created_at
 				 FROM exploration_evidence WHERE observation_id = ? ORDER BY file_path, start_line, id`,
 				[row.id]
 			) as ExplorationEvidence[];

--- a/src/mcp/entities/exploration-observation.ts
+++ b/src/mcp/entities/exploration-observation.ts
@@ -1,0 +1,220 @@
+import { createHash, randomUUID } from "node:crypto";
+import { BaseEntity } from "../storage/base";
+import type {
+	ExplorationEvidence,
+	ExplorationEvidenceInput,
+	ExplorationObservation,
+	ExplorationObservationInput,
+	ExplorationObservationRow
+} from "../types";
+
+interface EvidenceRow {
+	id: string;
+	observation_id: string;
+	file_path: string;
+	symbol_id: string | null;
+	start_line: number | null;
+	end_line: number | null;
+	created_at: string;
+}
+
+export interface ObservationQuery {
+	owner: string;
+	repo: string;
+	subject?: string;
+	task_id?: string;
+	file_path?: string;
+	symbol_id?: string;
+	min_confidence?: number;
+	limit?: number;
+	offset?: number;
+}
+
+export interface ObservationWriteResult {
+	observation: ExplorationObservation;
+	created: boolean;
+}
+
+function normalizeIdentityText(value: string): string {
+	return value.trim().replace(/\s+/g, " ").toLocaleLowerCase("en-US");
+}
+
+function evidenceIdentity(evidence: ExplorationEvidenceInput): string {
+	return [
+		evidence.file_path.trim(),
+		evidence.symbol_id?.trim() ?? "",
+		evidence.start_line ?? "",
+		evidence.end_line ?? ""
+	].join("\u001f");
+}
+
+export function observationIdentity(input: ExplorationObservationInput): string {
+	const normalizedEvidence = [...new Set(input.evidence.map(evidenceIdentity))].sort();
+	return createHash("sha256")
+		.update(
+			[normalizeIdentityText(input.subject), normalizeIdentityText(input.fact), ...normalizedEvidence].join("\u001e")
+		)
+		.digest("hex");
+}
+
+export class ExplorationObservationEntity extends BaseEntity {
+	upsertMany(
+		owner: string,
+		repo: string,
+		inputs: ExplorationObservationInput[],
+		updateId?: string
+	): ObservationWriteResult[] {
+		return this.transaction(() => inputs.map((input) => this.upsert(owner, repo, input, updateId)));
+	}
+
+	private upsert(
+		owner: string,
+		repo: string,
+		input: ExplorationObservationInput,
+		updateId?: string
+	): ObservationWriteResult {
+		const identityHash = observationIdentity(input);
+		const existing = updateId
+			? this.get<ExplorationObservationRow>(
+					"SELECT *, 0 AS evidence_count FROM exploration_observations WHERE id = ? AND owner = ? AND repo = ?",
+					[updateId, owner, repo]
+				)
+			: this.get<ExplorationObservationRow>(
+					"SELECT *, 0 AS evidence_count FROM exploration_observations WHERE owner = ? AND repo = ? AND identity_hash = ?",
+					[owner, repo, identityHash]
+				);
+
+		const now = new Date().toISOString();
+		if (existing) {
+			// A hash match without an explicit id is an idempotent retry: return the
+			// existing row byte-for-byte instead of churning updated_at/evidence.
+			if (!updateId) {
+				return { observation: this.getById(owner, repo, existing.id, true)!, created: false };
+			}
+			this.run(
+				`UPDATE exploration_observations
+				 SET subject = ?, fact = ?, confidence = ?, task_id = ?, agent = ?, identity_hash = ?, updated_at = ?
+				 WHERE id = ? AND owner = ? AND repo = ?`,
+				[
+					input.subject,
+					input.fact,
+					input.confidence,
+					input.task_id ?? null,
+					input.agent ?? null,
+					identityHash,
+					now,
+					existing.id,
+					owner,
+					repo
+				]
+			);
+			this.replaceEvidence(existing.id, input.evidence, now);
+			return { observation: this.getById(owner, repo, existing.id, true)!, created: false };
+		}
+
+		if (updateId) throw new Error(`Exploration observation not found: ${updateId}`);
+		const id = randomUUID();
+		this.run(
+			`INSERT INTO exploration_observations
+			 (id, owner, repo, subject, fact, confidence, task_id, agent, identity_hash, freshness, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'valid', ?, ?)`,
+			[
+				id,
+				owner,
+				repo,
+				input.subject,
+				input.fact,
+				input.confidence,
+				input.task_id ?? null,
+				input.agent ?? null,
+				identityHash,
+				now,
+				now
+			]
+		);
+		this.replaceEvidence(id, input.evidence, now);
+		return { observation: this.getById(owner, repo, id, true)!, created: true };
+	}
+
+	private replaceEvidence(observationId: string, evidence: ExplorationEvidenceInput[], now: string): void {
+		this.run("DELETE FROM exploration_evidence WHERE observation_id = ?", [observationId]);
+		const unique = new Map(evidence.map((item) => [evidenceIdentity(item), item]));
+		for (const item of unique.values()) {
+			this.run(
+				`INSERT INTO exploration_evidence
+				 (id, observation_id, file_path, symbol_id, start_line, end_line, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					randomUUID(),
+					observationId,
+					item.file_path,
+					item.symbol_id ?? null,
+					item.start_line ?? null,
+					item.end_line ?? null,
+					now
+				]
+			);
+		}
+	}
+
+	getById(owner: string, repo: string, id: string, hydrateEvidence = false): ExplorationObservation | null {
+		const row = this.get<ExplorationObservationRow>(
+			`SELECT o.*, COUNT(e.id) AS evidence_count
+			 FROM exploration_observations o
+			 LEFT JOIN exploration_evidence e ON e.observation_id = o.id
+			 WHERE o.id = ? AND o.owner = ? AND o.repo = ?
+			 GROUP BY o.id`,
+			[id, owner, repo]
+		);
+		return row ? this.hydrate(row, hydrateEvidence) : null;
+	}
+
+	list(query: ObservationQuery, hydrateEvidence = false): ExplorationObservation[] {
+		const conditions = ["o.owner = ?", "o.repo = ?", "o.confidence >= ?"];
+		const values: unknown[] = [query.owner, query.repo, query.min_confidence ?? 0];
+		if (query.subject) {
+			conditions.push("o.subject LIKE ?");
+			values.push(`%${query.subject}%`);
+		}
+		if (query.task_id) {
+			conditions.push("o.task_id = ?");
+			values.push(query.task_id);
+		}
+		if (query.file_path) {
+			conditions.push(
+				"EXISTS (SELECT 1 FROM exploration_evidence ef WHERE ef.observation_id = o.id AND ef.file_path = ?)"
+			);
+			values.push(query.file_path);
+		}
+		if (query.symbol_id) {
+			conditions.push(
+				"EXISTS (SELECT 1 FROM exploration_evidence es WHERE es.observation_id = o.id AND es.symbol_id = ?)"
+			);
+			values.push(query.symbol_id);
+		}
+		values.push(query.limit ?? 20, query.offset ?? 0);
+		const rows = this.all<ExplorationObservationRow>(
+			`SELECT o.*, COUNT(e.id) AS evidence_count
+			 FROM exploration_observations o
+			 LEFT JOIN exploration_evidence e ON e.observation_id = o.id
+			 WHERE ${conditions.join(" AND ")}
+			 GROUP BY o.id
+			 ORDER BY o.confidence DESC, o.updated_at DESC, o.id ASC
+			 LIMIT ? OFFSET ?`,
+			values
+		);
+		return rows.map((row) => this.hydrate(row, hydrateEvidence));
+	}
+
+	private hydrate(row: ExplorationObservationRow, includeEvidence: boolean): ExplorationObservation {
+		const observation: ExplorationObservation = { ...row, evidence_count: Number(row.evidence_count ?? 0) };
+		if (includeEvidence) {
+			observation.evidence = this.all<EvidenceRow>(
+				`SELECT id, observation_id, file_path, symbol_id, start_line, end_line, created_at
+				 FROM exploration_evidence WHERE observation_id = ? ORDER BY file_path, start_line, id`,
+				[row.id]
+			) as ExplorationEvidence[];
+		}
+		return observation;
+	}
+}

--- a/src/mcp/entities/exploration-observation.ts
+++ b/src/mcp/entities/exploration-observation.ts
@@ -323,10 +323,24 @@ export class ExplorationObservationEntity extends BaseEntity {
 				"SELECT * FROM codebase_symbols WHERE repo = ? AND file_path = ? ORDER BY start_line",
 				[observation.repo, item.file_path]
 			);
-			const matched = symbols.find((symbol) => fingerprintSymbol(symbol) === item.symbol_fingerprint);
-			const current = matched ?? symbols[0];
-			if (!current || (item.symbol_fingerprint && !matched)) {
-				setState("stale", current ? "symbol_changed" : "symbol_deleted");
+			if (!item.symbol_fingerprint) {
+				const exact = symbols.find((symbol) => symbol.id === item.symbol_id);
+				if (!exact) {
+					setState("unverifiable", "symbol_not_indexed");
+					continue;
+				}
+				this.updateEvidenceFingerprint(
+					item.id,
+					file.checksum,
+					exact.id,
+					fingerprintSymbol(exact),
+					file.last_indexed_at
+				);
+				continue;
+			}
+			const current = symbols.find((symbol) => fingerprintSymbol(symbol) === item.symbol_fingerprint);
+			if (!current) {
+				setState("stale", symbols.length > 0 ? "symbol_changed" : "symbol_deleted");
 				continue;
 			}
 			this.updateEvidenceFingerprint(

--- a/src/mcp/entities/knowledge-graph/dashboard-queries.ts
+++ b/src/mcp/entities/knowledge-graph/dashboard-queries.ts
@@ -4,34 +4,38 @@ import type { KgEntityRow, KgObservationRow, KgQueryRunner, KgRelationRow } from
 /**
  * Whether an entity with the given name exists.
  */
-export function entityExists(runner: KgQueryRunner, name: string): boolean {
-	return runner.get<{ present: number }>("SELECT 1 AS present FROM entities WHERE name = ?", [name]) !== undefined;
+export function entityExists(runner: KgQueryRunner, name: string, repo: string): boolean {
+	return (
+		runner.get<{ present: number }>("SELECT 1 AS present FROM entities WHERE name = ? AND repo = ?", [name, repo]) !==
+		undefined
+	);
 }
 
 /**
  * Full entity row by name (dashboard detail).
  */
-export function getEntityByName(runner: KgQueryRunner, name: string): KgEntityRow | undefined {
-	return runner.get<KgEntityRow>("SELECT * FROM entities WHERE name = ?", [name]);
+export function getEntityByName(runner: KgQueryRunner, name: string, repo: string): KgEntityRow | undefined {
+	return runner.get<KgEntityRow>("SELECT * FROM entities WHERE name = ? AND repo = ?", [name, repo]);
 }
 
 /**
  * Full relation rows touching the given entity (dashboard detail).
  */
-export function getRelationsByName(runner: KgQueryRunner, name: string): KgRelationRow[] {
+export function getRelationsByName(runner: KgQueryRunner, name: string, repo: string): KgRelationRow[] {
 	return runner.all<KgRelationRow>(
-		"SELECT * FROM relations WHERE from_entity = ? OR to_entity = ? ORDER BY relation_type",
-		[name, name]
+		"SELECT * FROM relations WHERE repo = ? AND (from_entity = ? OR to_entity = ?) ORDER BY relation_type",
+		[repo, name, name]
 	);
 }
 
 /**
  * Full observation rows for the given entity (dashboard detail).
  */
-export function getObservationsByName(runner: KgQueryRunner, name: string): KgObservationRow[] {
-	return runner.all<KgObservationRow>("SELECT * FROM observations WHERE entity_name = ? ORDER BY created_at DESC", [
-		name
-	]);
+export function getObservationsByName(runner: KgQueryRunner, name: string, repo: string): KgObservationRow[] {
+	return runner.all<KgObservationRow>(
+		"SELECT * FROM observations WHERE entity_name = ? AND repo = ? ORDER BY created_at DESC",
+		[name, repo]
+	);
 }
 
 /**

--- a/src/mcp/entities/knowledge-graph/entity.ts
+++ b/src/mcp/entities/knowledge-graph/entity.ts
@@ -38,20 +38,20 @@ export class KnowledgeGraphEntity extends BaseEntity {
 		};
 	}
 
-	/** Insert an entity, ignoring duplicates (entities.name is the primary key). */
+	/** Insert an entity, ignoring duplicates within its `(name, repo)` identity. */
 	upsertEntity(params: UpsertEntityParams): void {
 		writeUpsertEntity(this.writerRunner, params);
 	}
 
 	/**
-	 * Insert a relation, ignoring duplicates (composite PK on from_entity, to_entity, relation_type).
+	 * Insert a relation, ignoring duplicates within `(from_entity, to_entity, relation_type, repo)`.
 	 */
 	upsertRelation(params: UpsertRelationParams): void {
 		writeUpsertRelation(this.writerRunner, params);
 	}
 
 	/**
-	 * Resolve-or-upsert BOTH endpoints (global PK) then insert the relation —
+	 * Resolve-or-upsert BOTH repository-scoped endpoints then insert the relation —
 	 * idempotent against orphan-swept endpoints (TASK-065 / MEM-473). ATOMIC
 	 * (TASK-067 fix #2 / TASK-072): both upserts + insert run in one BEGIN
 	 * IMMEDIATE (base.ts immediate, TASK-064 / MEM-475).
@@ -265,14 +265,9 @@ export class KnowledgeGraphEntity extends BaseEntity {
 		writeCreateRelation(this.writerRunner, params);
 	}
 
-	/**
-	 * Fetch entity name/type rows for the given names. NOT repo-filtered —
-	 * `entities.name` is a global PK, so a repo predicate here filtered on
-	 * first-writer-wins rather than ownership and silently dropped entities
-	 * whose edges the response still shipped (audit F6 — see ./queries).
-	 */
-	getEntitiesFor(entityNames: string[]): Array<{ name: string; type: string }> {
-		return queries.getEntitiesFor(this.runner, entityNames);
+	/** Fetch entity name/type rows for names within one repository identity scope. */
+	getEntitiesFor(entityNames: string[], repo: string): Array<{ name: string; type: string }> {
+		return queries.getEntitiesFor(this.runner, entityNames, repo);
 	}
 
 	/**
@@ -305,23 +300,23 @@ export class KnowledgeGraphEntity extends BaseEntity {
 	}
 
 	/** Whether an entity with the given name exists. */
-	entityExists(name: string): boolean {
-		return queries.entityExists(this.runner, name);
+	entityExists(name: string, repo: string): boolean {
+		return queries.entityExists(this.runner, name, repo);
 	}
 
-	/** Full entity row by name (dashboard detail). */
-	getEntityByName(name: string): KgEntityRow | undefined {
-		return queries.getEntityByName(this.runner, name);
+	/** Full entity row by name within a repository scope (dashboard detail). */
+	getEntityByName(name: string, repo: string): KgEntityRow | undefined {
+		return queries.getEntityByName(this.runner, name, repo);
 	}
 
-	/** Full relation rows touching the given entity (dashboard detail). */
-	getRelationsByName(name: string): KgRelationRow[] {
-		return queries.getRelationsByName(this.runner, name);
+	/** Full relation rows touching the given entity within a repository scope. */
+	getRelationsByName(name: string, repo: string): KgRelationRow[] {
+		return queries.getRelationsByName(this.runner, name, repo);
 	}
 
-	/** Full observation rows for the given entity (dashboard detail). */
-	getObservationsByName(name: string): KgObservationRow[] {
-		return queries.getObservationsByName(this.runner, name);
+	/** Full observation rows for the given entity within a repository scope. */
+	getObservationsByName(name: string, repo: string): KgObservationRow[] {
+		return queries.getObservationsByName(this.runner, name, repo);
 	}
 
 	/** Entities scoped to a repo with optional type/search filters (dashboard); supports pagination. */
@@ -410,28 +405,19 @@ export class KnowledgeGraphEntity extends BaseEntity {
 		});
 	}
 
-	/**
-	 * Delete orphan entities GLOBALLY (repo-agnostic) — not referenced by ANY
-	 * observation or relation in ANY repo. TASK-043: safe ONLY from a
-	 * repo-agnostic maintenance pass (soul-maintenance).
-	 */
+	/** Delete repository-scoped entity rows with no same-repo observation or relation. */
 	deleteOrphanEntities(): number {
-		const result = this.run(`DELETE FROM entities WHERE name NOT IN (
-			SELECT DISTINCT entity_name FROM observations
-			UNION
-			SELECT DISTINCT from_entity FROM relations
-			UNION
-			SELECT DISTINCT to_entity FROM relations
-		)`);
+		const result = this.run(`DELETE FROM entities AS e WHERE
+			NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = e.name AND o.repo = e.repo)
+			AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.from_entity = e.name AND r.repo = e.repo)
+			AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.to_entity = e.name AND r.repo = e.repo)`);
 		return result.changes;
 	}
 
 	/**
-	 * Remove observations matching (text, repo) pairs — REPO-SCOPED — then
-	 * sweep orphan entities once — atomic. Cross-repo safety (TASK-043):
-	 * observation delete is repo-scoped, entity DELETE scoped to touched repos,
-	 * and the reference UNION is deliberately GLOBAL so a delete cannot
-	 * cascade across repos. `deleteOrphanEntities()` remains for maintenance.
+	 * Remove observations matching (text, repo) pairs, then sweep entities that
+	 * lost their last same-repo reference — atomic. Scoping is per repository,
+	 * so another repository's identically named entity is never affected.
 	 */
 	deleteObservationsAndOrphans(items: Array<{ text: string; repo: string }>): number {
 		return this.transaction(() => {
@@ -443,13 +429,10 @@ export class KnowledgeGraphEntity extends BaseEntity {
 			const repos = [...new Set(items.map((i) => i.repo))];
 			let orphanCount = 0;
 			if (repos.length > 0) {
-				const sweep = this.db.prepare(`DELETE FROM entities WHERE repo = ? AND name NOT IN (
-					SELECT DISTINCT entity_name FROM observations
-					UNION
-					SELECT DISTINCT from_entity FROM relations
-					UNION
-					SELECT DISTINCT to_entity FROM relations
-				)`);
+				const sweep = this.db.prepare(`DELETE FROM entities AS e WHERE e.repo = ?
+					AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = e.name AND o.repo = e.repo)
+					AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.from_entity = e.name AND r.repo = e.repo)
+					AND NOT EXISTS (SELECT 1 FROM relations r WHERE r.to_entity = e.name AND r.repo = e.repo)`);
 				for (const repo of repos) {
 					orphanCount += sweep.run(repo).changes;
 				}
@@ -482,16 +465,15 @@ export class KnowledgeGraphEntity extends BaseEntity {
 	}
 
 	/** Delete a relation by its composite key (dashboard). Returns rows changed. */
-	deleteRelation(from_entity: string, to_entity: string, relation_type: string): { changes: number } {
-		return this.run("DELETE FROM relations WHERE from_entity = ? AND to_entity = ? AND relation_type = ?", [
-			from_entity,
-			to_entity,
-			relation_type
-		]);
+	deleteRelation(from_entity: string, to_entity: string, relation_type: string, repo: string): { changes: number } {
+		return this.run(
+			"DELETE FROM relations WHERE from_entity = ? AND to_entity = ? AND relation_type = ? AND repo = ?",
+			[from_entity, to_entity, relation_type, repo]
+		);
 	}
 
-	/** Delete an entity by name (dashboard). Observations/relations removed via FK ON DELETE CASCADE. */
-	deleteEntity(name: string): { changes: number } {
-		return this.run("DELETE FROM entities WHERE name = ?", [name]);
+	/** Delete one repository-scoped entity; observations/relations cascade through composite FKs. */
+	deleteEntity(name: string, repo: string): { changes: number } {
+		return this.run("DELETE FROM entities WHERE name = ? AND repo = ?", [name, repo]);
 	}
 }

--- a/src/mcp/entities/knowledge-graph/queries.ts
+++ b/src/mcp/entities/knowledge-graph/queries.ts
@@ -1,9 +1,5 @@
 import { logger } from "../../utils/logger";
-import {
-	KG_MAX_CONTEXT_ENTITIES,
-	KG_CONTEXT_TEXT_TOKENS,
-	KG_MAX_CONTEXT_RELATIONS
-} from "../../utils/constants";
+import { KG_MAX_CONTEXT_ENTITIES, KG_CONTEXT_TEXT_TOKENS, KG_MAX_CONTEXT_RELATIONS } from "../../utils/constants";
 
 // ---------------------------------------------------------------------------
 // Query runner (TASK-176)
@@ -24,38 +20,17 @@ function tokenizeKgText(text: string): string[] {
 // Reads
 // ---------------------------------------------------------------------------
 
-/**
- * Fetch entity name/type rows for the given names.
- *
- * **No `repo` filter — deliberate (audit F6).** `entities.name` is a GLOBAL
- * `PRIMARY KEY` (v01 schema) and every writer uses `INSERT OR IGNORE`, so the
- * FIRST repo to mention a common noun (`priority`, `section`, `assignees`,
- * `due_date`) owns the row forever and every other repo's insert is silently
- * dropped. Adding `AND repo = ?` here therefore filtered on "which repo
- * happened to write this name first", not on ownership — and since the caller
- * has ALREADY scoped the name set by repo (via `observations WHERE repo = ?` or
- * the repo-filtered `entity_names_fts` index), the extra predicate could only
- * remove correct rows, never add safety.
- *
- * What it actually did was break the payload asymmetrically: `getEntitiesFor`
- * dropped the entity while `getRelationsFor` (which filters `relations.repo`,
- * a per-edge column that IS correct) still shipped its edges. Measured on a
- * real database: 2,209 of 19,294 `(entity_name, repo)` pairs (11.4%) referenced
- * an entity row owned by another repo, and for a 50-name window in one repo
- * `getEntitiesFor` returned **0** rows while `getRelationsFor` returned
- * **11,664 edges** whose endpoints were therefore absent from the response —
- * an unusable graph payload.
- *
- * Dropping the redundant predicate closes the payload. The proper fix for the
- * underlying schema flaw is a composite `(name, repo)` primary key, which needs
- * a table rebuild plus FK/trigger migration and is tracked separately.
- */
-export function getEntitiesFor(runner: KgQueryRunner, entityNames: string[]): Array<{ name: string; type: string }> {
+/** Fetch entity name/type rows for names within one repository identity scope. */
+export function getEntitiesFor(
+	runner: KgQueryRunner,
+	entityNames: string[],
+	repo: string
+): Array<{ name: string; type: string }> {
 	if (entityNames.length === 0) return [];
 	const placeholders = entityNames.map(() => "?").join(",");
 	return runner.all<{ name: string; type: string }>(
-		`SELECT name, type FROM entities WHERE name IN (${placeholders})`,
-		entityNames
+		`SELECT name, type FROM entities WHERE repo = ? AND name IN (${placeholders})`,
+		[repo, ...entityNames]
 	);
 }
 

--- a/src/mcp/entities/knowledge-graph/retention.ts
+++ b/src/mcp/entities/knowledge-graph/retention.ts
@@ -91,8 +91,8 @@ export class KnowledgeGraphRetentionEntity extends BaseEntity {
 			this.get<{ cnt: number }>(
 				`SELECT COUNT(*) AS cnt FROM relations r
 				 WHERE r.created_at < ?
-				   AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = r.from_entity)
-				   AND NOT EXISTS (SELECT 1 FROM observations o2 WHERE o2.entity_name = r.to_entity)`,
+				   AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = r.from_entity AND o.repo = r.repo)
+				   AND NOT EXISTS (SELECT 1 FROM observations o2 WHERE o2.entity_name = r.to_entity AND o2.repo = r.repo)`,
 				[cutoff]
 			)?.cnt ?? 0
 		);
@@ -104,23 +104,9 @@ export class KnowledgeGraphRetentionEntity extends BaseEntity {
 	 * Eligibility — BOTH must hold:
 	 *   - `created_at < cutoff` (age guard, so a freshly written edge is never
 	 *     racing the sweep), and
-	 *   - NEITHER endpoint appears in `observations` **in any repo**. Entity
-	 *     names are resolved exclusively through observations, so such an edge
-	 *     is unreachable from every entry point (`fetchKgContext`,
-	 *     `fetchAggregatedKgContext`, `fetchTaskKgContext` and the dashboard's
-	 *     entity detail all start from a name that came out of `observations`
-	 *     or `entity_names_fts`, and the latter only holds names that have an
-	 *     `entities` row — which the orphan sweep keeps only while an
-	 *     observation or relation references it).
-	 *
-	 * The endpoint check is deliberately repo-AGNOSTIC (`NOT EXISTS ... WHERE
-	 * entity_name = ?` with no `repo` predicate), matching
-	 * `deleteOrphanEntities`'s global UNION: a name observed in ANOTHER repo is
-	 * still a live name, and `entities.name` is a GLOBAL primary key, so a
-	 * repo-scoped check would delete edges whose endpoint is legitimately owned
-	 * by a different repo. Measured difference on a real database: repo-scoped
-	 * would have taken 576,674 edges, repo-agnostic takes 395,215 — the 181,459
-	 * difference is exactly the cross-repo-reachable set that must be kept.
+	 *   - NEITHER endpoint appears in `observations` in the SAME repo. Entity
+	 *     identity is `(name, repo)` since migration v33, so observations in a
+	 *     different repository cannot make this edge reachable.
 	 *
 	 * **Bounded by construction.** Every `DELETE` fires the v22 `kg_degrees`
 	 * triggers (2 UPDATEs + 1 conditional DELETE per row), so throughput is
@@ -149,7 +135,10 @@ export class KnowledgeGraphRetentionEntity extends BaseEntity {
 		// entirely. `idx_relations_created_at` (migration v29) makes this a
 		// single index probe (<1ms) instead of paying the correlated NOT EXISTS
 		// scan just to learn there is nothing to do.
-		if (this.get<{ present: number }>("SELECT 1 AS present FROM relations WHERE created_at < ? LIMIT 1", [cutoff]) === undefined) {
+		if (
+			this.get<{ present: number }>("SELECT 1 AS present FROM relations WHERE created_at < ? LIMIT 1", [cutoff]) ===
+			undefined
+		) {
 			return 0;
 		}
 
@@ -165,8 +154,8 @@ export class KnowledgeGraphRetentionEntity extends BaseEntity {
 		const deleteChunkSql = `DELETE FROM relations WHERE rowid IN (
 			   SELECT r.rowid FROM relations r
 			   WHERE r.created_at < ?
-			     AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = r.from_entity)
-			     AND NOT EXISTS (SELECT 1 FROM observations o2 WHERE o2.entity_name = r.to_entity)
+			     AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.entity_name = r.from_entity AND o.repo = r.repo)
+			     AND NOT EXISTS (SELECT 1 FROM observations o2 WHERE o2.entity_name = r.to_entity AND o2.repo = r.repo)
 			   LIMIT ?
 			 )`;
 

--- a/src/mcp/entities/knowledge-graph/writers.ts
+++ b/src/mcp/entities/knowledge-graph/writers.ts
@@ -60,7 +60,7 @@ export interface CreateRelationParams {
 	confidence?: number;
 }
 
-/** Insert an entity, ignoring duplicates (entities.name is the primary key). */
+/** Insert an entity, ignoring duplicates within its `(name, repo)` identity. */
 export function upsertEntity(runner: KgWriteRunner, params: UpsertEntityParams): void {
 	runner.run(
 		`INSERT OR IGNORE INTO entities (name, type, description, repo, owner, created_at, updated_at)
@@ -70,7 +70,7 @@ export function upsertEntity(runner: KgWriteRunner, params: UpsertEntityParams):
 }
 
 /**
- * Insert a relation, ignoring duplicates (composite PK on from_entity, to_entity, relation_type).
+ * Insert a relation, ignoring duplicates within `(from_entity, to_entity, relation_type, repo)`.
  *
  * `confidence` is the per-edge KG confidence label (migration v24, [KGCONF-1]
  * / TASK-325): an INSERT-TIME constant chosen by the CALLER SITE (the

--- a/src/mcp/entities/reuse-telemetry.ts
+++ b/src/mcp/entities/reuse-telemetry.ts
@@ -1,0 +1,81 @@
+import { BaseEntity } from "../storage/base";
+
+export interface ReuseTelemetryDelta {
+	owner: string;
+	repo: string;
+	bucket: string;
+	metric: string;
+	source: string;
+	count: number;
+	value: number;
+}
+
+export interface ReuseTelemetrySummary {
+	from: string;
+	to: string;
+	metrics: Record<
+		string,
+		{ count: number; value: number; by_source: Record<string, { count: number; value: number }> }
+	>;
+}
+
+interface SummaryRow {
+	metric: string;
+	source: string;
+	count: number;
+	value: number;
+}
+
+export class ReuseTelemetryEntity extends BaseEntity {
+	flush(deltas: ReuseTelemetryDelta[]): void {
+		if (deltas.length === 0) return;
+		this.transaction(() => {
+			for (const delta of deltas) {
+				this.run(
+					`INSERT INTO reuse_telemetry_hourly (owner, repo, bucket, metric, source, count, value)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(owner, repo, bucket, metric, source) DO UPDATE SET
+					 count = count + excluded.count, value = value + excluded.value`,
+					[delta.owner, delta.repo, delta.bucket, delta.metric, delta.source, delta.count, delta.value]
+				);
+			}
+		});
+	}
+
+	summarize(owner: string, repo: string, hours = 24): ReuseTelemetrySummary {
+		const boundedHours = Math.max(1, Math.min(24 * 90, Math.trunc(hours)));
+		const to = new Date();
+		const from = new Date(to.getTime() - boundedHours * 3_600_000);
+		const rows = this.all<SummaryRow>(
+			`SELECT metric, source, SUM(count) AS count, SUM(value) AS value
+			 FROM reuse_telemetry_hourly
+			 WHERE owner = ? AND repo = ? AND bucket >= ?
+			 GROUP BY metric, source ORDER BY metric, source`,
+			[owner, repo, from.toISOString()]
+		);
+		const metrics: ReuseTelemetrySummary["metrics"] = {};
+		for (const row of rows) {
+			const metric = (metrics[row.metric] ??= { count: 0, value: 0, by_source: {} });
+			metric.count += row.count;
+			metric.value += row.value;
+			if (row.source) metric.by_source[row.source] = { count: row.count, value: row.value };
+		}
+		return { from: from.toISOString(), to: to.toISOString(), metrics };
+	}
+
+	prune(retentionDays: number, maxRows: number): number {
+		const days = Math.max(1, Math.min(365, Math.trunc(retentionDays)));
+		const cap = Math.max(24, Math.trunc(maxRows));
+		return this.transaction(() => {
+			const cutoff = new Date(Date.now() - days * 86_400_000).toISOString();
+			const expired = this.run("DELETE FROM reuse_telemetry_hourly WHERE bucket < ?", [cutoff]).changes;
+			const overflow = this.run(
+				`DELETE FROM reuse_telemetry_hourly WHERE rowid IN (
+					SELECT rowid FROM reuse_telemetry_hourly ORDER BY bucket DESC LIMIT -1 OFFSET ?
+				)`,
+				[cap]
+			).changes;
+			return expired + overflow;
+		});
+	}
+}

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -195,7 +195,9 @@ export function createRouter(
 			// eliminates the legacy "log + rethrow raw exception" divergence so
 			// both transports surface identical shapes for the same failure class.
 			logger.error(`[Tool] ${toolName} failed`, { repo, error: String(err) });
-			return toErrorResponse(err);
+			const errorResponse = toErrorResponse(err);
+			logToolAction(db, toolName, args, errorResponse);
+			return errorResponse;
 		}
 
 		// Log only { repo } — never the full result payload, so memory/task

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -38,6 +38,7 @@ import { ElicitationRequestHandler } from "./elicitation";
 import { getLogLevel, LOG_LEVEL_VALUES, setLogLevel } from "./utils/logger";
 import { getRuntimeCapabilities, isSemanticToolDemand } from "./runtime-capabilities";
 import { decodeCursor, encodeCursor } from "./utils/pagination";
+import { reuseTelemetry } from "./utils/reuse-telemetry";
 
 type RouterOptions = {
 	getSessionContext?: () => SessionContext;
@@ -217,6 +218,16 @@ export function createRouter(
 			// metadata from result.structuredContent and logs under the
 			// no-file-lock policy.
 			logToolAction(db, toolName, args, result);
+			const session = getSessionContext?.();
+			reuseTelemetry.recordTool({
+				owner: String(args.owner ?? ""),
+				repo: String(args.repo ?? "unknown"),
+				session: [session?.sessionId, args.task_code ?? args.task_id ?? ""].join(":"),
+				toolName,
+				args,
+				result
+			});
+			reuseTelemetry.flushIfNeeded(db);
 		} catch (e) {
 			logger.error("Failed to log action", { toolName, error: String(e) });
 		}

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -36,6 +36,7 @@ import { VectorStore } from "./types";
 import { SamplingRequestHandler } from "./sampling";
 import { ElicitationRequestHandler } from "./elicitation";
 import { getLogLevel, LOG_LEVEL_VALUES, setLogLevel } from "./utils/logger";
+import { getRuntimeCapabilities, isSemanticToolDemand } from "./runtime-capabilities";
 import { decodeCursor, encodeCursor } from "./utils/pagination";
 
 type RouterOptions = {
@@ -175,6 +176,12 @@ export function createRouter(
 		const isWrite = WRITE_TOOLS.has(toolName);
 
 		logger.info(`[Tool] ${toolName}`, { repo, write: isWrite });
+
+		// Same lazy semantic trigger as the SDK path so both transports share
+		// one capability lifecycle.
+		if (isSemanticToolDemand(toolName, args)) {
+			void getRuntimeCapabilities().ensure("semantic");
+		}
 
 		let result: unknown;
 		try {

--- a/src/mcp/runtime-capabilities.ts
+++ b/src/mcp/runtime-capabilities.ts
@@ -1,0 +1,170 @@
+import { performance } from "node:perf_hooks";
+
+export const RUNTIME_PROFILES = ["minimal", "balanced", "full"] as const;
+export type RuntimeProfile = (typeof RUNTIME_PROFILES)[number];
+
+export const RUNTIME_CAPABILITIES = ["semantic", "indexing", "watcher", "maintenance", "dashboard"] as const;
+export type RuntimeCapability = (typeof RUNTIME_CAPABILITIES)[number];
+export type CapabilityState = "unavailable" | "idle" | "loading" | "ready" | "degraded" | "failed";
+
+export interface CapabilitySnapshot {
+	state: CapabilityState;
+	loaded_at: string | null;
+	duration_ms: number | null;
+	error: string | null;
+}
+
+export interface RuntimeCapabilitySnapshot {
+	profile: RuntimeProfile;
+	capabilities: Record<RuntimeCapability, CapabilitySnapshot>;
+	footprint: { rss_bytes: number; heap_used_bytes: number };
+}
+
+type CapabilityLoader = () => void | Promise<void>;
+const PROFILE_CAPABILITIES: Record<RuntimeProfile, ReadonlySet<RuntimeCapability>> = {
+	minimal: new Set(["dashboard"]),
+	balanced: new Set(["semantic", "indexing", "dashboard"]),
+	full: new Set(RUNTIME_CAPABILITIES)
+};
+
+export function resolveRuntimeProfile(value = process.env.MCP_RUNTIME_PROFILE): RuntimeProfile {
+	return RUNTIME_PROFILES.includes(value as RuntimeProfile) ? (value as RuntimeProfile) : "full";
+}
+
+export class RuntimeCapabilityRegistry {
+	readonly profile: RuntimeProfile;
+	private readonly loaders = new Map<RuntimeCapability, CapabilityLoader>();
+	private readonly inFlight = new Map<RuntimeCapability, Promise<boolean>>();
+	private readonly status = new Map<RuntimeCapability, CapabilitySnapshot>();
+
+	constructor(profile: RuntimeProfile = resolveRuntimeProfile()) {
+		this.profile = profile;
+		for (const capability of RUNTIME_CAPABILITIES) {
+			this.status.set(capability, {
+				state: PROFILE_CAPABILITIES[profile].has(capability) ? "idle" : "unavailable",
+				loaded_at: null,
+				duration_ms: null,
+				error: null
+			});
+		}
+	}
+
+	register(capability: RuntimeCapability, loader: CapabilityLoader): void {
+		if (!this.loaders.has(capability)) this.loaders.set(capability, loader);
+	}
+
+	unregister(capability: RuntimeCapability): void {
+		this.loaders.delete(capability);
+	}
+
+	disable(capability: RuntimeCapability, reason: string): void {
+		this.loaders.delete(capability);
+		this.status.set(capability, {
+			state: "unavailable",
+			loaded_at: null,
+			duration_ms: null,
+			error: reason
+		});
+	}
+
+	hasLoader(capability: RuntimeCapability): boolean {
+		return this.loaders.has(capability);
+	}
+
+	isAvailable(capability: RuntimeCapability): boolean {
+		return this.status.get(capability)?.state !== "unavailable";
+	}
+
+	async ensure(capability: RuntimeCapability): Promise<boolean> {
+		const current = this.status.get(capability)!;
+		if (current.state === "unavailable") return false;
+		if (current.state === "ready") return true;
+		if (current.state === "degraded") return false;
+		const active = this.inFlight.get(capability);
+		if (active) return active;
+		const loader = this.loaders.get(capability);
+		if (!loader) {
+			this.status.set(capability, { ...current, state: "degraded", error: "No capability loader registered" });
+			return false;
+		}
+		const started = performance.now();
+		this.status.set(capability, { ...current, state: "loading", error: null });
+		const loading = Promise.resolve()
+			.then(loader)
+			.then(() => {
+				this.status.set(capability, {
+					state: "ready",
+					loaded_at: new Date().toISOString(),
+					duration_ms: Math.round((performance.now() - started) * 100) / 100,
+					error: null
+				});
+				return true;
+			})
+			.catch((error: unknown) => {
+				this.status.set(capability, {
+					state: "failed",
+					loaded_at: null,
+					duration_ms: Math.round((performance.now() - started) * 100) / 100,
+					error: error instanceof Error ? error.message : String(error)
+				});
+				return false;
+			})
+			.finally(() => this.inFlight.delete(capability));
+		this.inFlight.set(capability, loading);
+		return loading;
+	}
+
+	async warmup(capabilities: readonly RuntimeCapability[]): Promise<RuntimeCapabilitySnapshot> {
+		await Promise.all(capabilities.map((capability) => this.ensure(capability)));
+		return this.snapshot();
+	}
+
+	reset(capability: RuntimeCapability): void {
+		if (!this.isAvailable(capability)) return;
+		this.status.set(capability, { state: "idle", loaded_at: null, duration_ms: null, error: null });
+	}
+
+	markReady(capability: RuntimeCapability): void {
+		if (!this.isAvailable(capability)) return;
+		this.status.set(capability, {
+			state: "ready",
+			loaded_at: new Date().toISOString(),
+			duration_ms: 0,
+			error: null
+		});
+	}
+
+	markDegraded(capability: RuntimeCapability, reason: string): void {
+		if (!this.isAvailable(capability)) return;
+		const current = this.status.get(capability)!;
+		this.status.set(capability, { ...current, state: "degraded", error: reason });
+	}
+
+	snapshot(): RuntimeCapabilitySnapshot {
+		const memory = process.memoryUsage();
+		return {
+			profile: this.profile,
+			capabilities: Object.fromEntries(
+				RUNTIME_CAPABILITIES.map((capability) => [capability, { ...this.status.get(capability)! }])
+			) as Record<RuntimeCapability, CapabilitySnapshot>,
+			footprint: { rss_bytes: memory.rss, heap_used_bytes: memory.heapUsed }
+		};
+	}
+}
+
+let activeRegistry: RuntimeCapabilityRegistry | null = null;
+
+export function getRuntimeCapabilities(): RuntimeCapabilityRegistry {
+	activeRegistry ??= new RuntimeCapabilityRegistry();
+	return activeRegistry;
+}
+
+export function setRuntimeCapabilities(registry: RuntimeCapabilityRegistry): void {
+	activeRegistry = registry;
+}
+
+export function isSemanticToolDemand(toolName: string, args: Record<string, unknown>): boolean {
+	if (["memory-write", "standard-write", "task-write"].includes(toolName)) return true;
+	if (!["memory-read", "standard-read", "task-read", "agent-context"].includes(toolName)) return false;
+	return typeof args.query === "string" || typeof args.objective === "string";
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,13 +7,15 @@ import { createMcpServer } from "./mcp-server";
 import { updateSessionFromInitialize } from "./session";
 import { SQLiteStore } from "./storage/sqlite";
 import { RealVectorStore } from "./storage/vectors";
+import { CapabilityAwareVectorStore } from "./storage/lazy-vectors";
 import { EmbeddingWorker } from "./embedding-queue";
+import { RuntimeCapabilityRegistry, setRuntimeCapabilities } from "./runtime-capabilities";
 import { CAPABILITIES } from "./capabilities";
 import { addLogSink, createFileSink, logger } from "./utils/logger";
 import { runStartupMaintenance } from "./services/maintenance-job";
 import { runCliIndex } from "./codebase-index/cli";
 import { autoIndexIfStale } from "./codebase-index/services/indexing-service";
-import { TreeSitterParserPool } from "./codebase-index/parser/parser-pool";
+import { getCodebaseParserPool } from "./codebase-index/parser/singleton";
 import { FileWatcher, registerRepo } from "./codebase-index/services/file-watcher";
 import fs from "fs";
 import path from "path";
@@ -96,9 +98,13 @@ process.on("uncaughtException", (err: Error) => {
 	});
 });
 
-// Create storage instances
+// Create the core store first. Optional engines are registered below and
+// initialized through one single-flight capability registry.
 const db = await SQLiteStore.create();
-const vectors = new RealVectorStore(db);
+const realVectors = new RealVectorStore(db);
+const runtimeCapabilities = new RuntimeCapabilityRegistry();
+setRuntimeCapabilities(runtimeCapabilities);
+const vectors = new CapabilityAwareVectorStore(realVectors, runtimeCapabilities);
 
 // Register file log sink (same dir as DB, retain last 5 files) BEFORE the
 // embedding worker starts (TASK-457 fix8): embeddingWorker.start() runs the
@@ -110,52 +116,53 @@ addLogSink(createFileSink(path.dirname(db.getDbPath())));
 // Start the embedding/KG outbox worker (TASK-013): drains queue_jobs with
 // batched ONNX inference + KG extraction OUTSIDE the write lock. Startup
 // reconcile/backfill/purge run inside the worker.
-const embeddingWorker = new EmbeddingWorker(db, vectors);
-embeddingWorker.start();
+const embeddingWorker = new EmbeddingWorker(db, realVectors);
+runtimeCapabilities.register("semantic", async () => {
+	// Preserve the worker's independent retry/maintenance loop even if the
+	// first ONNX initialization fails.
+	embeddingWorker.start();
+	await realVectors.initialize();
+});
 
-// Parser pool for codebase indexing — shared by the startup auto-index and
-// the polling file watcher (TASK-322 / US-08). Lazy-initialized on first
-// parse (TreeSitterParserPool.parseFile auto-initializes), so no eager WASM
-// load here. NOTE: tools/codebase-index.ts keeps its own lazy singleton pool
-// (used by MCP tool + dashboard index calls); two pools coexist bounded by
-// the per-language WASM cache.
-const parserPool = new TreeSitterParserPool();
-
-// Polling file watcher (TASK-322 / US-08): sweeps registered repos over
-// autoIndexIfStale with a short TTL — no fs.watch. Hosted ONLY by this MCP
-// server process (the dashboard runs its own index path in a separate
-// process; hosting the loop there too would double-index). Gated by
-// ENABLE_FILE_WATCHER (default enabled). The startup auto-index block below
-// registers the CWD repo so the watcher keeps it fresh.
-const fileWatcher = new FileWatcher(db, parserPool);
-fileWatcher.start();
-
-logger.info("[Server] startup", { pid: process.pid, version: CAPABILITIES.serverInfo.version, db: db.getDbPath() });
-
-// Pre-load vector model — block startup until ready or timeout (30s)
-try {
-	await Promise.race([
-		vectors.initialize(),
-		new Promise((_, reject) => setTimeout(() => reject(new Error("Vector model init timed out after 30s")), 30000))
-	]);
-	logger.info("[Server] Vector model loaded (384-dim)");
-} catch (err) {
-	logger.warn("[Server] Vector model init failed. Will retry on first use.", { error: String(err) });
+// Parser and watcher objects are not constructed until their capabilities are
+// demanded. All paths still share the process-wide parser singleton.
+let fileWatcher: FileWatcher | null = null;
+runtimeCapabilities.register("indexing", () => getCodebaseParserPool().initialize());
+runtimeCapabilities.register("watcher", () => {
+	fileWatcher ??= new FileWatcher(db, getCodebaseParserPool());
+	fileWatcher.start();
+});
+if (process.env.ENABLE_FILE_WATCHER === "false") {
+	runtimeCapabilities.disable("watcher", "Disabled via ENABLE_FILE_WATCHER=false");
 }
+runtimeCapabilities.register("maintenance", async () => {
+	const result = await runStartupMaintenance(db);
+	if (!result.skipped) {
+		logger.info("[Server] Startup maintenance complete", {
+			decayed: result.decay.decayed,
+			archived: result.expiredArchived + result.lowScoreArchived + result.decay.archived
+		});
+	}
+});
 
-// Run startup maintenance: memory decay, expired archiving, and low-score archiving
-runStartupMaintenance(db)
-	.then((result) => {
-		if (!result.skipped) {
-			logger.info("[Server] Startup maintenance complete", {
-				decayed: result.decay.decayed,
-				archived: result.expiredArchived + result.lowScoreArchived + result.decay.archived
-			});
-		}
-	})
-	.catch((err) => {
-		logger.error("[Server] Startup maintenance failed", { error: String(err) });
-	});
+logger.info("[Server] startup", {
+	pid: process.pid,
+	version: CAPABILITIES.serverInfo.version,
+	db: db.getDbPath(),
+	profile: runtimeCapabilities.profile
+});
+
+if (runtimeCapabilities.profile === "full") {
+	try {
+		await Promise.race([
+			runtimeCapabilities.ensure("semantic"),
+			new Promise((_, reject) => setTimeout(() => reject(new Error("Semantic warm-up timed out after 30s")), 30000))
+		]);
+	} catch (error) {
+		logger.warn("[Server] Semantic warm-up failed. Will retry on first use.", { error: String(error) });
+	}
+	void runtimeCapabilities.ensure("maintenance");
+}
 
 // Run startup auto-index: triggers codebase indexing for the current working
 // directory if the index has never been built or is older than TTL (default
@@ -164,28 +171,26 @@ runStartupMaintenance(db)
 // runs in the background; the dashboard polls /api/codebase/index-status.
 // The repo is registered with the file watcher so the polling sweep keeps it
 // fresh after the first build (watch set = startup repo + tool-indexed repos).
-{
+if (runtimeCapabilities.profile === "full" && process.env.CODEBASE_AUTO_INDEX !== "false") {
 	const repoName = path.basename(process.cwd());
 	const repoPath = process.cwd();
 	registerRepo(repoName, repoPath);
-	void parserPool
-		.initialize()
-		.then(() => {
-			void autoIndexIfStale(repoName, repoPath, db, parserPool)
-				.then((result) => {
-					logger.info("[Server] Auto-index check complete", {
-						repo: repoName,
-						status: result.status,
-						reason: result.reason
-					});
-				})
-				.catch((err) => {
-					logger.warn("[Server] Auto-index check failed", { error: String(err) });
+	void runtimeCapabilities.ensure("indexing").then((ready) => {
+		if (!ready) return;
+		void autoIndexIfStale(repoName, repoPath, db, getCodebaseParserPool())
+			.then((result) => {
+				logger.info("[Server] Auto-index check complete", {
+					repo: repoName,
+					status: result.status,
+					reason: result.reason
 				});
-		})
-		.catch((err) => {
-			logger.warn("[Server] Auto-index parser pool initialization failed", { error: String(err) });
-		});
+				void runtimeCapabilities.ensure("watcher");
+			})
+			.catch((err) => {
+				runtimeCapabilities.markDegraded("indexing", String(err));
+				logger.warn("[Server] Auto-index check failed", { error: String(err) });
+			});
+	});
 }
 
 // Ignore EPIPE errors on stdout/stderr (e.g. if the client disconnects prematurely)
@@ -203,7 +208,7 @@ process.stderr.on("error", (err: unknown) => {
 const shutdown = async (signal: string) => {
 	logger.info("[Server] shutdown", { signal, pid: process.pid });
 	embeddingWorker.stop();
-	fileWatcher.stop();
+	fileWatcher?.stop();
 	await handle?.close();
 	db.close();
 	process.exit(0);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -12,6 +12,7 @@ import { EmbeddingWorker } from "./embedding-queue";
 import { RuntimeCapabilityRegistry, setRuntimeCapabilities } from "./runtime-capabilities";
 import { CAPABILITIES } from "./capabilities";
 import { addLogSink, createFileSink, logger } from "./utils/logger";
+import { reuseTelemetry } from "./utils/reuse-telemetry";
 import { runStartupMaintenance } from "./services/maintenance-job";
 import { runCliIndex } from "./codebase-index/cli";
 import { autoIndexIfStale } from "./codebase-index/services/indexing-service";
@@ -210,6 +211,7 @@ const shutdown = async (signal: string) => {
 	embeddingWorker.stop();
 	fileWatcher?.stop();
 	await handle?.close();
+	reuseTelemetry.flush(db);
 	db.close();
 	process.exit(0);
 };

--- a/src/mcp/services/soul-maintenance.ts
+++ b/src/mcp/services/soul-maintenance.ts
@@ -268,10 +268,8 @@ export function pruneObservations(knowledgeGraph: KnowledgeGraphEntity, retentio
  * to 77% of total DB size at ~70k edges/day on a real deployment with no
  * mechanism to ever shrink.
  *
- * Eligibility requires BOTH an age guard and unreachability, and the endpoint
- * check is repo-agnostic — see `KnowledgeGraphEntity.deleteUnreachableRelations`
- * for why (a name observed in another repo is still live, and `entities.name` is
- * a global primary key).
+ * Eligibility requires BOTH an age guard and same-repository unreachability;
+ * migration v33 makes `(name, repo)` the entity identity.
  *
  * Bounded per run (`maxRows`) and per transaction (`chunkSize`) so a large
  * backlog converges across maintenance cycles instead of blocking one startup

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 export type McpRoot = {
@@ -25,6 +26,9 @@ export type SessionContext = {
 	owner?: string;
 	repo?: string;
 	projectPath?: string;
+
+	// Opaque process-local correlation identifier; never derived from prompt text.
+	sessionId?: string;
 
 	// From initialize handshake (per-connection)
 	clientName?: string;
@@ -60,6 +64,7 @@ export function createSessionContext(): SessionContext {
 		owner,
 		repo,
 		projectPath,
+		sessionId: randomUUID(),
 		clientName: undefined,
 		clientVersion: undefined,
 		lastSeenModel: undefined,

--- a/src/mcp/storage/base.ts
+++ b/src/mcp/storage/base.ts
@@ -221,6 +221,7 @@ export abstract class BaseEntity {
 			semantic_signature: row.semantic_signature ?? null,
 			semantic_source: row.semantic_source ?? null,
 			semantic_updated_at: row.semantic_updated_at ?? null,
+			source_fingerprint: row.source_fingerprint ?? null,
 			created_at: row.created_at,
 			updated_at: row.updated_at
 		};

--- a/src/mcp/storage/lazy-vectors.ts
+++ b/src/mcp/storage/lazy-vectors.ts
@@ -1,0 +1,36 @@
+import type { VectorEntityKind, VectorResult, VectorStore } from "../types";
+import type { RuntimeCapabilityRegistry } from "../runtime-capabilities";
+
+export class CapabilityAwareVectorStore implements VectorStore {
+	constructor(
+		private readonly inner: VectorStore,
+		private readonly capabilities: RuntimeCapabilityRegistry
+	) {}
+
+	async initialize(): Promise<void> {
+		await this.capabilities.ensure("semantic");
+	}
+
+	getInnerStore(): VectorStore {
+		return this.inner;
+	}
+
+	async embed(texts: string[]): Promise<number[][]> {
+		if (!(await this.capabilities.ensure("semantic"))) return [];
+		const semantic = this.inner as VectorStore & { embed?: (values: string[]) => Promise<number[][]> };
+		return semantic.embed ? semantic.embed(texts) : [];
+	}
+
+	async upsert(id: string, text: string, kind?: VectorEntityKind): Promise<void> {
+		if (await this.capabilities.ensure("semantic")) await this.inner.upsert(id, text, kind);
+	}
+
+	async remove(id: string, kind?: VectorEntityKind): Promise<void> {
+		await this.inner.remove(id, kind);
+	}
+
+	async search(query: string, limit: number, repo?: string, kind?: VectorEntityKind): Promise<VectorResult[]> {
+		if (!(await this.capabilities.ensure("semantic"))) return [];
+		return this.inner.search(query, limit, repo, kind);
+	}
+}

--- a/src/mcp/storage/migrations/index.ts
+++ b/src/mcp/storage/migrations/index.ts
@@ -30,8 +30,9 @@ import { migration as v26 } from "./v26-codebase-references-role";
 import { migration as v27 } from "./v27-codebase-references-import-metadata";
 import { migration as v28 } from "./v28-codebase-symbols-semantic";
 import { migration as v29 } from "./v29-kg-relations-index-rebalance";
+import { migration as v30 } from "./v30-exploration-observations";
 
-export const SCHEMA_VERSION = 29;
+export const SCHEMA_VERSION = 30;
 
 /**
  * A single versioned schema migration. `up` runs inside the migration runner's
@@ -76,7 +77,8 @@ const MIGRATIONS: Migration[] = [
 	v26,
 	v27,
 	v28,
-	v29
+	v29,
+	v30
 ];
 
 // ──────────────────────────────────────────────

--- a/src/mcp/storage/migrations/index.ts
+++ b/src/mcp/storage/migrations/index.ts
@@ -33,8 +33,9 @@ import { migration as v29 } from "./v29-kg-relations-index-rebalance";
 import { migration as v30 } from "./v30-exploration-observations";
 import { migration as v31 } from "./v31-observation-freshness";
 import { migration as v32 } from "./v32-reuse-telemetry";
+import { migration as v33 } from "./v33-kg-repo-identity";
 
-export const SCHEMA_VERSION = 32;
+export const SCHEMA_VERSION = 33;
 
 /**
  * A single versioned schema migration. `up` runs inside the migration runner's
@@ -82,7 +83,8 @@ const MIGRATIONS: Migration[] = [
 	v29,
 	v30,
 	v31,
-	v32
+	v32,
+	v33
 ];
 
 // ──────────────────────────────────────────────

--- a/src/mcp/storage/migrations/index.ts
+++ b/src/mcp/storage/migrations/index.ts
@@ -32,8 +32,9 @@ import { migration as v28 } from "./v28-codebase-symbols-semantic";
 import { migration as v29 } from "./v29-kg-relations-index-rebalance";
 import { migration as v30 } from "./v30-exploration-observations";
 import { migration as v31 } from "./v31-observation-freshness";
+import { migration as v32 } from "./v32-reuse-telemetry";
 
-export const SCHEMA_VERSION = 31;
+export const SCHEMA_VERSION = 32;
 
 /**
  * A single versioned schema migration. `up` runs inside the migration runner's
@@ -80,7 +81,8 @@ const MIGRATIONS: Migration[] = [
 	v28,
 	v29,
 	v30,
-	v31
+	v31,
+	v32
 ];
 
 // ──────────────────────────────────────────────

--- a/src/mcp/storage/migrations/index.ts
+++ b/src/mcp/storage/migrations/index.ts
@@ -31,8 +31,9 @@ import { migration as v27 } from "./v27-codebase-references-import-metadata";
 import { migration as v28 } from "./v28-codebase-symbols-semantic";
 import { migration as v29 } from "./v29-kg-relations-index-rebalance";
 import { migration as v30 } from "./v30-exploration-observations";
+import { migration as v31 } from "./v31-observation-freshness";
 
-export const SCHEMA_VERSION = 30;
+export const SCHEMA_VERSION = 31;
 
 /**
  * A single versioned schema migration. `up` runs inside the migration runner's
@@ -78,7 +79,8 @@ const MIGRATIONS: Migration[] = [
 	v27,
 	v28,
 	v29,
-	v30
+	v30,
+	v31
 ];
 
 // ──────────────────────────────────────────────

--- a/src/mcp/storage/migrations/v15-entity-names-fts.ts
+++ b/src/mcp/storage/migrations/v15-entity-names-fts.ts
@@ -26,8 +26,9 @@ export const migration: Migration = {
 		// write path (entity methods, dashboard raw inserts, orphan
 		// sweeps) lands on the entities table, so the triggers keep the
 		// index consistent without touching any call site. DELETE is
-		// cascade-safe: entities.name is the table PK, and the _ad trigger
-		// fires per deleted row regardless of the delete's origin.
+		// cascade-safe: the _ad trigger fires per deleted entity row regardless
+		// of the delete's origin. Migration v33 later widens identity to
+		// `(name, repo)` and recreates this FTS table and its triggers.
 		//
 		// Matching semantics (documented in getEntityNamesByText): FTS5
 		// unicode61 tokenization matches NAME TOKENS against search-text

--- a/src/mcp/storage/migrations/v30-exploration-observations.ts
+++ b/src/mcp/storage/migrations/v30-exploration-observations.ts
@@ -1,0 +1,47 @@
+import { logger } from "../../utils/logger";
+import type { Migration } from "./index";
+
+export const migration: Migration = {
+	version: 30,
+	name: "exploration-observations",
+	up: (db) => {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS exploration_observations (
+				id TEXT PRIMARY KEY,
+				owner TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				subject TEXT NOT NULL,
+				fact TEXT NOT NULL,
+				confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+				task_id TEXT,
+				agent TEXT,
+				identity_hash TEXT NOT NULL,
+				freshness TEXT NOT NULL DEFAULT 'valid' CHECK (freshness IN ('valid', 'stale', 'unverifiable')),
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				UNIQUE (owner, repo, identity_hash)
+			);
+			CREATE TABLE IF NOT EXISTS exploration_evidence (
+				id TEXT PRIMARY KEY,
+				observation_id TEXT NOT NULL REFERENCES exploration_observations(id) ON DELETE CASCADE,
+				file_path TEXT NOT NULL,
+				symbol_id TEXT,
+				start_line INTEGER,
+				end_line INTEGER,
+				created_at TEXT NOT NULL,
+				UNIQUE (observation_id, file_path, symbol_id, start_line, end_line)
+			);
+			CREATE INDEX IF NOT EXISTS idx_exploration_obs_scope_subject
+				ON exploration_observations(owner, repo, subject);
+			CREATE INDEX IF NOT EXISTS idx_exploration_obs_scope_task
+				ON exploration_observations(owner, repo, task_id);
+			CREATE INDEX IF NOT EXISTS idx_exploration_obs_scope_confidence
+				ON exploration_observations(owner, repo, confidence DESC);
+			CREATE INDEX IF NOT EXISTS idx_exploration_evidence_file
+				ON exploration_evidence(file_path, observation_id);
+			CREATE INDEX IF NOT EXISTS idx_exploration_evidence_symbol
+				ON exploration_evidence(symbol_id, observation_id);
+		`);
+		logger.info("[Migration] Added structured exploration observations and normalized evidence");
+	}
+};

--- a/src/mcp/storage/migrations/v31-observation-freshness.ts
+++ b/src/mcp/storage/migrations/v31-observation-freshness.ts
@@ -1,0 +1,47 @@
+import { logger } from "../../utils/logger";
+import type { Migration } from "./index";
+
+export const migration: Migration = {
+	version: 31,
+	name: "observation-freshness",
+	up: (db) => {
+		const symbolColumns = new Set(
+			(db.prepare("PRAGMA table_info(codebase_symbols)").all() as Array<{ name: string }>).map(({ name }) => name)
+		);
+		if (!symbolColumns.has("source_fingerprint")) {
+			db.exec("ALTER TABLE codebase_symbols ADD COLUMN source_fingerprint TEXT");
+		}
+		const columns = new Set(
+			(db.prepare("PRAGMA table_info(exploration_evidence)").all() as Array<{ name: string }>).map(({ name }) => name)
+		);
+		for (const [name, definition] of [
+			["file_checksum", "TEXT"],
+			["symbol_fingerprint", "TEXT"],
+			["indexed_at", "TEXT"],
+			["commit_sha", "TEXT"]
+		] as const) {
+			if (!columns.has(name)) db.exec(`ALTER TABLE exploration_evidence ADD COLUMN ${name} ${definition}`);
+		}
+		const observationColumns = new Set(
+			(db.prepare("PRAGMA table_info(exploration_observations)").all() as Array<{ name: string }>).map(
+				({ name }) => name
+			)
+		);
+		if (!observationColumns.has("stale_reason")) {
+			db.exec("ALTER TABLE exploration_observations ADD COLUMN stale_reason TEXT");
+		}
+		if (!observationColumns.has("last_verified_at")) {
+			db.exec("ALTER TABLE exploration_observations ADD COLUMN last_verified_at TEXT");
+		}
+		if (!observationColumns.has("superseded_by")) {
+			db.exec(
+				"ALTER TABLE exploration_observations ADD COLUMN superseded_by TEXT REFERENCES exploration_observations(id)"
+			);
+		}
+		db.exec(`
+			CREATE INDEX IF NOT EXISTS idx_exploration_obs_scope_freshness
+				ON exploration_observations(owner, repo, freshness, confidence DESC);
+		`);
+		logger.info("[Migration] Added exploration evidence fingerprints and freshness lifecycle metadata");
+	}
+};

--- a/src/mcp/storage/migrations/v32-reuse-telemetry.ts
+++ b/src/mcp/storage/migrations/v32-reuse-telemetry.ts
@@ -1,0 +1,26 @@
+import { logger } from "../../utils/logger";
+import type { Migration } from "./index";
+
+export const migration: Migration = {
+	version: 32,
+	name: "reuse-telemetry-aggregates",
+	up: (db) => {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS reuse_telemetry_hourly (
+				owner TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				bucket TEXT NOT NULL,
+				metric TEXT NOT NULL,
+				source TEXT NOT NULL DEFAULT '',
+				count INTEGER NOT NULL DEFAULT 0,
+				value REAL NOT NULL DEFAULT 0,
+				PRIMARY KEY (owner, repo, bucket, metric, source)
+			);
+			CREATE INDEX IF NOT EXISTS idx_reuse_telemetry_bucket
+				ON reuse_telemetry_hourly(bucket);
+			CREATE INDEX IF NOT EXISTS idx_reuse_telemetry_scope_bucket
+				ON reuse_telemetry_hourly(owner, repo, bucket);
+		`);
+		logger.info("[Migration] Added bounded hourly context-reuse telemetry aggregates");
+	}
+};

--- a/src/mcp/storage/migrations/v33-kg-repo-identity.ts
+++ b/src/mcp/storage/migrations/v33-kg-repo-identity.ts
@@ -1,0 +1,147 @@
+import { logger } from "../../utils/logger";
+import type { Migration } from "./index";
+
+/**
+ * Rebuild the legacy global-name KG into repository-scoped identities.
+ *
+ * Historical rows are expanded to every `(name, repo)` scope proven by an
+ * entity, observation, or relation. The original entity supplies type,
+ * description, and timestamps; each scoped source supplies owner/repo. The
+ * migration runs inside MigrationManager's transaction, so any copy/FK/index
+ * failure restores the complete pre-v33 schema and data.
+ *
+ * Rollback after deployment requires restoring the pre-migration DB backup:
+ * collapsing duplicate names back to a global PK is inherently lossy. Operators
+ * should stop all writers and create a SQLite backup before first v33 startup.
+ */
+export const migration: Migration = {
+	version: 33,
+	name: "kg-repo-identity",
+	up: (db) => {
+		const pk = db.prepare("PRAGMA table_info(entities)").all() as Array<{ name: string; pk: number }>;
+		if (pk.some((column) => column.name === "repo" && column.pk === 2)) {
+			logger.debug("[Migration] Repository-scoped KG identity already present, skipping rebuild");
+			return;
+		}
+
+		db.exec(`
+			DROP TRIGGER IF EXISTS entity_names_fts_ai;
+			DROP TRIGGER IF EXISTS entity_names_fts_au;
+			DROP TRIGGER IF EXISTS entity_names_fts_ad;
+			DROP TABLE IF EXISTS entity_names_fts;
+			DROP TRIGGER IF EXISTS trg_kg_degrees_ai;
+			DROP TRIGGER IF EXISTS trg_kg_degrees_ad;
+
+			CREATE TEMP TABLE kg_entity_scopes (
+				name TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				owner TEXT NOT NULL,
+				PRIMARY KEY (name, repo)
+			) WITHOUT ROWID;
+
+			INSERT OR IGNORE INTO kg_entity_scopes (name, repo, owner)
+			SELECT name, repo, MIN(owner) FROM entities GROUP BY name, repo;
+			INSERT OR IGNORE INTO kg_entity_scopes (name, repo, owner)
+			SELECT entity_name, repo, MIN(owner) FROM observations GROUP BY entity_name, repo;
+			INSERT OR IGNORE INTO kg_entity_scopes (name, repo, owner)
+			SELECT from_entity, repo, MIN(owner) FROM relations GROUP BY from_entity, repo;
+			INSERT OR IGNORE INTO kg_entity_scopes (name, repo, owner)
+			SELECT to_entity, repo, MIN(owner) FROM relations GROUP BY to_entity, repo;
+
+			CREATE TABLE entities_v33 (
+				name TEXT NOT NULL,
+				type TEXT NOT NULL DEFAULT 'unknown',
+				description TEXT,
+				repo TEXT NOT NULL DEFAULT '',
+				owner TEXT NOT NULL DEFAULT '',
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (name, repo)
+			);
+
+			INSERT INTO entities_v33 (name, type, description, repo, owner, created_at, updated_at)
+			SELECT s.name, COALESCE(e.type, 'unknown'), e.description, s.repo, s.owner,
+			       COALESCE(e.created_at, CURRENT_TIMESTAMP), COALESCE(e.updated_at, CURRENT_TIMESTAMP)
+			FROM kg_entity_scopes s LEFT JOIN entities e ON e.name = s.name;
+
+			CREATE TABLE relations_v33 (
+				from_entity TEXT NOT NULL,
+				to_entity TEXT NOT NULL,
+				relation_type TEXT NOT NULL,
+				repo TEXT NOT NULL DEFAULT '',
+				owner TEXT NOT NULL DEFAULT '',
+				created_at TEXT NOT NULL,
+				confidence REAL NOT NULL DEFAULT 1.0,
+				PRIMARY KEY (from_entity, to_entity, relation_type, repo),
+				FOREIGN KEY (from_entity, repo) REFERENCES entities_v33(name, repo) ON DELETE CASCADE,
+				FOREIGN KEY (to_entity, repo) REFERENCES entities_v33(name, repo) ON DELETE CASCADE
+			);
+			INSERT INTO relations_v33 SELECT from_entity, to_entity, relation_type, repo, owner, created_at, confidence FROM relations;
+
+			CREATE TABLE observations_v33 (
+				id TEXT PRIMARY KEY,
+				entity_name TEXT NOT NULL,
+				observation TEXT NOT NULL,
+				repo TEXT NOT NULL DEFAULT '',
+				owner TEXT NOT NULL DEFAULT '',
+				created_at TEXT NOT NULL,
+				FOREIGN KEY (entity_name, repo) REFERENCES entities_v33(name, repo) ON DELETE CASCADE
+			);
+			INSERT INTO observations_v33 SELECT id, entity_name, observation, repo, owner, created_at FROM observations;
+
+			DROP TABLE observations;
+			DROP TABLE relations;
+			DROP TABLE entities;
+			ALTER TABLE entities_v33 RENAME TO entities;
+			ALTER TABLE relations_v33 RENAME TO relations;
+			ALTER TABLE observations_v33 RENAME TO observations;
+			DROP TABLE kg_entity_scopes;
+
+			CREATE INDEX idx_entities_type ON entities(type);
+			CREATE INDEX idx_entities_repo ON entities(repo);
+			CREATE INDEX idx_relations_to ON relations(to_entity);
+			CREATE INDEX idx_relations_repo ON relations(repo);
+			CREATE INDEX idx_relations_repo_from_to ON relations(repo, from_entity, to_entity);
+			CREATE INDEX idx_relations_repo_to ON relations(repo, to_entity);
+			CREATE INDEX idx_relations_created_at ON relations(created_at);
+			CREATE INDEX idx_observations_entity ON observations(entity_name);
+			CREATE INDEX idx_observations_repo ON observations(repo);
+			CREATE INDEX idx_observations_created_at ON observations(created_at);
+			CREATE INDEX idx_observations_observation ON observations(observation);
+			CREATE UNIQUE INDEX idx_observations_dedup ON observations(entity_name, observation, repo);
+
+			CREATE VIRTUAL TABLE entity_names_fts USING fts5(name, repo UNINDEXED, tokenize='unicode61');
+			CREATE TRIGGER entity_names_fts_ai AFTER INSERT ON entities BEGIN
+				INSERT INTO entity_names_fts(rowid, name, repo) VALUES (new.rowid, new.name, new.repo);
+			END;
+			CREATE TRIGGER entity_names_fts_au AFTER UPDATE ON entities BEGIN
+				DELETE FROM entity_names_fts WHERE rowid = old.rowid;
+				INSERT INTO entity_names_fts(rowid, name, repo) VALUES (new.rowid, new.name, new.repo);
+			END;
+			CREATE TRIGGER entity_names_fts_ad AFTER DELETE ON entities BEGIN
+				DELETE FROM entity_names_fts WHERE rowid = old.rowid;
+			END;
+			INSERT INTO entity_names_fts(rowid, name, repo) SELECT rowid, name, repo FROM entities;
+
+			DELETE FROM kg_degrees;
+			INSERT INTO kg_degrees (repo, node, degree)
+			SELECT repo, from_entity, COUNT(*) FROM relations GROUP BY repo, from_entity;
+			INSERT INTO kg_degrees (repo, node, degree)
+			SELECT repo, to_entity, COUNT(*) FROM relations GROUP BY repo, to_entity
+			ON CONFLICT(repo, node) DO UPDATE SET degree = kg_degrees.degree + excluded.degree;
+			CREATE TRIGGER trg_kg_degrees_ai AFTER INSERT ON relations BEGIN
+				INSERT INTO kg_degrees (repo, node, degree) VALUES (NEW.repo, NEW.from_entity, 1)
+				ON CONFLICT(repo, node) DO UPDATE SET degree = kg_degrees.degree + 1;
+				INSERT INTO kg_degrees (repo, node, degree) VALUES (NEW.repo, NEW.to_entity, 1)
+				ON CONFLICT(repo, node) DO UPDATE SET degree = kg_degrees.degree + 1;
+			END;
+			CREATE TRIGGER trg_kg_degrees_ad AFTER DELETE ON relations BEGIN
+				UPDATE kg_degrees SET degree = degree - 1 WHERE repo = OLD.repo AND node = OLD.from_entity AND degree > 0;
+				UPDATE kg_degrees SET degree = degree - 1 WHERE repo = OLD.repo AND node = OLD.to_entity AND degree > 0;
+				DELETE FROM kg_degrees WHERE repo = OLD.repo AND (node = OLD.from_entity OR node = OLD.to_entity) AND degree = 0;
+			END;
+		`);
+
+		logger.info("[Migration] Rebuilt knowledge graph with repository-scoped entity and relation identities");
+	}
+};

--- a/src/mcp/storage/sqlite.ts
+++ b/src/mcp/storage/sqlite.ts
@@ -19,6 +19,7 @@ import { CodebaseSymbolEntity } from "../entities/codebase-symbol";
 import { CodebaseReferenceEntity } from "../entities/codebase-reference";
 import { KnowledgeGraphEntity } from "../entities/knowledge-graph";
 import { ExplorationObservationEntity } from "../entities/exploration-observation";
+import { ReuseTelemetryEntity } from "../entities/reuse-telemetry";
 import { WriteLock } from "./write-lock";
 import { logger } from "../utils/logger";
 import { WAL_CHECKPOINT_INTERVAL_MS } from "../utils/constants";
@@ -65,6 +66,7 @@ export class SQLiteStore {
 	public codebaseReferences: CodebaseReferenceEntity;
 	public knowledgeGraph: KnowledgeGraphEntity;
 	public explorationObservations: ExplorationObservationEntity;
+	public reuseTelemetry: ReuseTelemetryEntity;
 	public lock: WriteLock;
 	private dbPathInstance: string;
 	/** Last wall-clock time a WAL checkpoint ran (throttles refresh()). */
@@ -131,6 +133,7 @@ export class SQLiteStore {
 		this.codebaseReferences = new CodebaseReferenceEntity(this.db);
 		this.knowledgeGraph = new KnowledgeGraphEntity(this.db);
 		this.explorationObservations = new ExplorationObservationEntity(this.db);
+		this.reuseTelemetry = new ReuseTelemetryEntity(this.db);
 		this.lock = new WriteLock(finalPath);
 	}
 

--- a/src/mcp/storage/sqlite.ts
+++ b/src/mcp/storage/sqlite.ts
@@ -18,6 +18,7 @@ import { CodebaseFileEntity } from "../entities/codebase-file";
 import { CodebaseSymbolEntity } from "../entities/codebase-symbol";
 import { CodebaseReferenceEntity } from "../entities/codebase-reference";
 import { KnowledgeGraphEntity } from "../entities/knowledge-graph";
+import { ExplorationObservationEntity } from "../entities/exploration-observation";
 import { WriteLock } from "./write-lock";
 import { logger } from "../utils/logger";
 import { WAL_CHECKPOINT_INTERVAL_MS } from "../utils/constants";
@@ -63,6 +64,7 @@ export class SQLiteStore {
 	public codebaseSymbols: CodebaseSymbolEntity;
 	public codebaseReferences: CodebaseReferenceEntity;
 	public knowledgeGraph: KnowledgeGraphEntity;
+	public explorationObservations: ExplorationObservationEntity;
 	public lock: WriteLock;
 	private dbPathInstance: string;
 	/** Last wall-clock time a WAL checkpoint ran (throttles refresh()). */
@@ -128,6 +130,7 @@ export class SQLiteStore {
 		this.codebaseSymbols = new CodebaseSymbolEntity(this.db);
 		this.codebaseReferences = new CodebaseReferenceEntity(this.db);
 		this.knowledgeGraph = new KnowledgeGraphEntity(this.db);
+		this.explorationObservations = new ExplorationObservationEntity(this.db);
 		this.lock = new WriteLock(finalPath);
 	}
 

--- a/src/mcp/storage/vectors.ts
+++ b/src/mcp/storage/vectors.ts
@@ -8,6 +8,7 @@ type FeatureExtractionPipeline = import("@xenova/transformers").FeatureExtractio
 export class RealVectorStore implements VectorStore {
 	private db: SQLiteStore;
 	private extractor: FeatureExtractionPipeline | null = null;
+	private extractorPromise: Promise<FeatureExtractionPipeline> | null = null;
 	private modelName = "Xenova/all-MiniLM-L6-v2";
 	private transformersModule: typeof import("@xenova/transformers") | null = null;
 
@@ -34,11 +35,19 @@ export class RealVectorStore implements VectorStore {
 	}
 
 	private async getExtractor(): Promise<FeatureExtractionPipeline> {
-		if (!this.extractor) {
-			const tf = await this.getTransformers();
-			this.extractor = await tf.pipeline("feature-extraction", this.modelName);
-		}
-		return this.extractor;
+		if (this.extractor) return this.extractor;
+		if (this.extractorPromise) return this.extractorPromise;
+
+		this.extractorPromise = this.getTransformers()
+			.then((tf) => tf.pipeline("feature-extraction", this.modelName))
+			.then((extractor) => {
+				this.extractor = extractor;
+				return extractor;
+			})
+			.finally(() => {
+				this.extractorPromise = null;
+			});
+		return this.extractorPromise;
 	}
 
 	/**

--- a/src/mcp/tests/agent-context.contract.test.ts
+++ b/src/mcp/tests/agent-context.contract.test.ts
@@ -113,6 +113,25 @@ describe("Agent Context - response and performance contract", () => {
 		expect(p95).toBeLessThan(250);
 	});
 
+	it("returns the same opaque pack id for an explicit correlation key", async () => {
+		seedMemory(1);
+		const args = {
+			owner,
+			repo,
+			objective: "bounded compiler",
+			sources: ["memories"] as const,
+			context_pack_id: "shared-pack-key",
+			json: true
+		};
+		const first = await handleAgentContext(args, db, vectors);
+		const second = await handleAgentContext(args, db, vectors);
+		const firstData = first.structuredContent as { context_pack_id: string };
+		const secondData = second.structuredContent as { context_pack_id: string };
+		expect(firstData.context_pack_id).toBe(secondData.context_pack_id);
+		expect(firstData.context_pack_id).not.toContain("shared-pack-key");
+		expect(second).toBe(first);
+	});
+
 	it("keeps compact text without structured JSON and includes it when requested", async () => {
 		seedMemory(1);
 		const args = { owner, repo, objective: "bounded compiler", sources: ["memories"] as const };
@@ -126,6 +145,7 @@ describe("Agent Context - response and performance contract", () => {
 		const structured = await handleAgentContext({ ...args, json: true }, db, vectors);
 		expect(structured.structuredContent).toMatchObject({
 			schema: "agent-context",
+			context_pack_id: expect.stringMatching(/^[a-f0-9]{24}$/),
 			repo,
 			memories: expect.any(Array),
 			decisions: expect.any(Array),

--- a/src/mcp/tests/agent-context.contract.test.ts
+++ b/src/mcp/tests/agent-context.contract.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, it, expect } from "vitest";
+import { AgentContextSchema } from "../tools/schemas/index";
+import { MemoryWriteSchema } from "../tools/schemas/memory";
+import { handleAgentContext } from "../tools/agent-context";
+import { createTestStore } from "../storage/sqlite";
+import { StubVectorStore } from "../storage/vectors.stub";
+import type { MemoryEntry, VectorStore } from "../types";
+import { AGENT_TOOL_DEFINITIONS } from "../types/tool-definitions/agent";
+
+describe("Agent Context - Schema Validation (AgentContextSchema)", () => {
+	it("should reject empty owner", () => {
+		expect(() => AgentContextSchema.parse({ owner: "", repo: "test" })).toThrow();
+	});
+
+	it("should reject empty repo", () => {
+		expect(() => AgentContextSchema.parse({ owner: "test", repo: "" })).toThrow();
+	});
+
+	it("should accept query as optional string", () => {
+		const result = AgentContextSchema.parse({ owner: "test", repo: "test", query: "search term" });
+		expect(result.query).toBe("search term");
+	});
+
+	it("should accept search via query field", () => {
+		const result = AgentContextSchema.parse({
+			owner: "test",
+			repo: "test",
+			query: "old search"
+		});
+		expect(result.query).toBe("old search");
+	});
+
+	it("should apply default limit of 5", () => {
+		const result = AgentContextSchema.parse({ owner: "test", repo: "test" });
+		expect(result.limit).toBe(5);
+	});
+
+	it("should apply default json false", () => {
+		const result = AgentContextSchema.parse({ owner: "test", repo: "test" });
+		expect(result.json).toBe(false);
+	});
+
+	it("accepts compiler inputs and applies bounded defaults", () => {
+		const result = AgentContextSchema.parse({ owner: "test", repo: "test", objective: "ship feature" });
+		expect(result.budget).toEqual({ tokens: 2000, max_items: 20, code_depth: 1 });
+		expect(result.sources).toEqual(["memories", "decisions", "tasks", "handoffs", "standards", "observations", "code"]);
+	});
+
+	it("rejects unsafe compiler budgets and unknown sources", () => {
+		expect(() => AgentContextSchema.parse({ owner: "test", repo: "test", budget: { tokens: 255 } })).toThrow();
+		expect(() => AgentContextSchema.parse({ owner: "test", repo: "test", sources: ["internet"] })).toThrow();
+	});
+});
+
+describe("Agent Context - response and performance contract", () => {
+	let db: Awaited<ReturnType<typeof createTestStore>>;
+	let vectors: VectorStore;
+	const owner = "test";
+	const repo = "agent-context-contract";
+
+	beforeEach(async () => {
+		db = await createTestStore();
+		vectors = new StubVectorStore(db);
+	});
+
+	function seedMemory(index: number): void {
+		const now = new Date().toISOString();
+		const entry: MemoryEntry = {
+			id: crypto.randomUUID(),
+			type: "code_fact",
+			title: `Contract memory ${index}`,
+			content: `Bounded compiler candidate ${index} `.repeat(12),
+			importance: 3,
+			agent: "test-agent",
+			role: "unknown",
+			model: "test-model",
+			scope: { owner, repo },
+			created_at: now,
+			updated_at: now,
+			completed_at: null,
+			hit_count: 0,
+			recall_count: 0,
+			last_used_at: null,
+			expires_at: null,
+			supersedes: null,
+			status: "active",
+			tags: [],
+			metadata: {},
+			is_global: false
+		};
+		db.memories.insert(entry);
+	}
+
+	it("keeps warm in-memory compilation p95 below 250ms", async () => {
+		for (let i = 0; i < 40; i++) seedMemory(i);
+		const args = {
+			owner,
+			repo,
+			objective: "bounded compiler",
+			sources: ["memories"] as const,
+			budget: { tokens: 2_000, max_items: 20, code_depth: 0 },
+			json: true
+		};
+		await handleAgentContext(args, db, vectors);
+		const durations: number[] = [];
+		for (let i = 0; i < 20; i++) {
+			const started = performance.now();
+			await handleAgentContext(args, db, vectors);
+			durations.push(performance.now() - started);
+		}
+		durations.sort((a, b) => a - b);
+		const p95 = durations[Math.ceil(durations.length * 0.95) - 1]!;
+		expect(p95).toBeLessThan(250);
+	});
+
+	it("keeps compact text without structured JSON and includes it when requested", async () => {
+		seedMemory(1);
+		const args = { owner, repo, objective: "bounded compiler", sources: ["memories"] as const };
+		const compact = await handleAgentContext(args, db, vectors);
+		expect(compact.structuredContent).toBeUndefined();
+		expect(compact.content).toHaveLength(1);
+		const [content] = compact.content ?? [];
+		if (content?.type !== "text") throw new Error("Expected text content");
+		expect(content.text).toContain("Relevant Memories");
+
+		const structured = await handleAgentContext({ ...args, json: true }, db, vectors);
+		expect(structured.structuredContent).toMatchObject({
+			schema: "agent-context",
+			repo,
+			memories: expect.any(Array),
+			decisions: expect.any(Array),
+			tasks: expect.any(Array)
+		});
+	});
+});
+
+describe("Agent Context - decision-log and session-summarize removed", () => {
+	it("decision-log/session-summarize logic replaced by flat fields in memory-write", () => {
+		// Verify the flat decision fields exist on memory-write schema
+		const shape = MemoryWriteSchema.shape || {};
+		const keys = Object.keys(shape);
+		expect(keys).toContain("context");
+		expect(keys).toContain("rationale");
+		expect(keys).toContain("alternatives");
+		expect(keys).toContain("key_decisions");
+		expect(keys).toContain("next_steps");
+	});
+
+	it("agent-context definition no longer lists decision-log or session-summarize tools", () => {
+		const toolNames = AGENT_TOOL_DEFINITIONS.map((t: { name: string }) => t.name);
+		expect(toolNames).not.toContain("decision-log");
+		expect(toolNames).not.toContain("session-summarize");
+	});
+});

--- a/src/mcp/tests/agent-context.test.ts
+++ b/src/mcp/tests/agent-context.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { handleAgentContext } from "../tools/agent-context";
 import { createTestStore } from "../storage/sqlite";
 import { StubVectorStore } from "../storage/vectors.stub";
-import type { VectorStore, MemoryEntry } from "../types";
-import { AgentContextSchema } from "../tools/schemas/index";
-// DecisionLogSchema and SessionSummarizeSchema removed per ADR-007.
-// Use memory-write with flat fields: context/rationale/alternatives, key_decisions/next_steps
-import { MemoryWriteSchema } from "../tools/schemas/memory";
-import { AGENT_TOOL_DEFINITIONS } from "../types/tool-definitions/agent";
+import type { VectorStore, MemoryEntry, CodingStandardEntry } from "../types";
 import type { McpResponse } from "../utils/mcp-response";
 
 /** Shape of handleAgentContext's structuredContent (see tools/agent-context.ts). */
@@ -34,6 +29,10 @@ interface AgentContextResult {
 		status: string;
 		priority: number;
 	}>;
+	context: Array<{ source: string; id: string; estimated_tokens: number }>;
+	estimated_tokens: number;
+	allocation: { included_items: number };
+	exclusions: Array<{ source: string; id: string; reason: string }>;
 }
 
 /** Narrow McpResponse.structuredContent (unknown) to the agent-context result shape. */
@@ -81,8 +80,6 @@ describe("Agent Context - handleAgentContext", () => {
 		db = await createTestStore();
 		vectors = new StubVectorStore(db);
 	});
-
-	// ─── query param (new canonical) ─────────────────────────────────────
 
 	it("should return memories matching the query param", async () => {
 		seedMemory({ title: "Auth Setup", content: "JWT tokens with 1h expiry." });
@@ -238,19 +235,231 @@ describe("Agent Context - handleAgentContext", () => {
 		expect(taskCodes).toContain("AC-001");
 	});
 
-	// ─── JSON output ─────────────────────────────────────────────────────
+	// ─── token-budgeted multi-source compiler ────────────────────────────
 
-	it("should return structured JSON when json:true", async () => {
-		seedMemory({ title: "JSON Test", content: "Testing JSON output format." });
+	it("compiles deterministic context within the requested token and item budgets", async () => {
+		for (let i = 0; i < 8; i++) {
+			seedMemory({
+				title: `Compiler memory ${i}`,
+				content: `Deterministic compiler evidence ${i} `.repeat(20),
+				importance: i === 0 ? 5 : 3
+			});
+		}
 
-		const res = await handleAgentContext({ owner: OWNER, repo: REPO, limit: 5, json: true }, db, vectors);
+		const args = {
+			owner: OWNER,
+			repo: REPO,
+			objective: "deterministic compiler",
+			budget: { tokens: 256, max_items: 3, code_depth: 1 },
+			json: true
+		};
+		const first = getStructured(await handleAgentContext(args, db, vectors));
+		const second = getStructured(await handleAgentContext(args, db, vectors));
 
-		expect(res.structuredContent).toBeDefined();
-		expect(getStructured(res).schema).toBe("agent-context");
-		expect(getStructured(res).repo).toBe(REPO);
-		expect(Array.isArray(getStructured(res).memories)).toBe(true);
-		expect(Array.isArray(getStructured(res).tasks)).toBe(true);
-		expect(Array.isArray(getStructured(res).decisions)).toBe(true);
+		expect(first.context).toEqual(second.context);
+		expect(first.context.length).toBeLessThanOrEqual(3);
+		expect(first.estimated_tokens).toBeLessThanOrEqual(256);
+		expect(first.allocation.included_items).toBe(first.context.length);
+		expect(first.exclusions.some((entry) => entry.reason === "token_budget" || entry.reason === "item_budget")).toBe(
+			true
+		);
+	});
+
+	it("prioritizes an explicitly requested task and supports source selection", async () => {
+		const now = new Date().toISOString();
+		db.tasks.insertTask({
+			id: crypto.randomUUID(),
+			task_code: "AC-CRITICAL",
+			owner: OWNER,
+			repo: REPO,
+			phase: "implementation",
+			title: "Critical compiler task",
+			description: "Preserve the requested task under a constrained context budget.",
+			status: "in_progress",
+			priority: 5,
+			agent: "test-agent",
+			role: "implementation",
+			doc_path: null,
+			created_at: now,
+			updated_at: now,
+			in_progress_at: now,
+			finished_at: null,
+			canceled_at: null,
+			est_tokens: 100,
+			commit_id: null,
+			changed_files: [],
+			tags: [],
+			suggested_skills: [],
+			metadata: {},
+			parent_id: null,
+			depends_on: null
+		});
+		seedMemory({ title: "Noise", content: "Unrelated memory that must not leak through source selection." });
+
+		const result = getStructured(
+			await handleAgentContext(
+				{
+					owner: OWNER,
+					repo: REPO,
+					task_code: "AC-CRITICAL",
+					sources: ["tasks"],
+					budget: { tokens: 256, max_items: 1, code_depth: 0 },
+					json: true
+				},
+				db,
+				vectors
+			)
+		);
+
+		expect(result.context).toHaveLength(1);
+		expect(result.context[0].source).toBe("tasks");
+		expect(result.context[0].id).toBe("AC-CRITICAL");
+		expect(result.memories).toEqual([]);
+		expect(result.tasks.map((task) => task.task_code)).toEqual(["AC-CRITICAL"]);
+	});
+
+	it("retrieves handoffs, standards, fresh observations, and indexed code pointers", async () => {
+		const now = new Date().toISOString();
+		db.handoffs.createHandoff({
+			owner: OWNER,
+			repo: REPO,
+			from_agent: "scout",
+			summary: "Inspect the compiler contract."
+		});
+		const standard: CodingStandardEntry = {
+			id: crypto.randomUUID(),
+			code: "STD-COMPILER",
+			title: "Compiler standard",
+			content: "Keep context compilation deterministic and bounded.",
+			parent_id: null,
+			context: "agent context",
+			version: "1.0.0",
+			language: "typescript",
+			stack: [],
+			is_global: false,
+			owner: OWNER,
+			repo: REPO,
+			tags: [],
+			metadata: {},
+			created_at: now,
+			updated_at: now,
+			hit_count: 0,
+			last_used_at: null,
+			agent: "test-agent",
+			model: "test-model"
+		};
+		db.standards.insert(standard);
+		db.codebaseFiles.upsertFile({
+			repo: REPO,
+			file_path: "src/compiler.ts",
+			language: "typescript",
+			checksum: "compiler-checksum",
+			lines: 10,
+			size_bytes: 100
+		});
+		db.codebaseFiles.upsertFile({
+			repo: REPO,
+			file_path: "src/budget.ts",
+			language: "typescript",
+			checksum: "budget-checksum",
+			lines: 6,
+			size_bytes: 60
+		});
+		db.codebaseSymbols.bulkUpsertSymbols([
+			{
+				id: "123e4567-e89b-42d3-a456-426614174101",
+				repo: REPO,
+				file_path: "src/compiler.ts",
+				name: "compileContext",
+				kind: "function",
+				exported: true,
+				start_line: 1,
+				end_line: 8,
+				signature: "compileContext(): Context"
+			},
+			{
+				id: "123e4567-e89b-42d3-a456-426614174102",
+				repo: REPO,
+				file_path: "src/budget.ts",
+				name: "estimateBudget",
+				kind: "function",
+				exported: true,
+				start_line: 1,
+				end_line: 5,
+				signature: "estimateBudget(): number"
+			}
+		]);
+		db.codebaseReferences.bulkUpsertReferences(REPO, [
+			{
+				repo: REPO,
+				symbol_name: "estimateBudget",
+				caller_file: "src/compiler.ts",
+				caller_line: 4,
+				caller_name: "compileContext",
+				kind: "call",
+				target_file: "src/budget.ts",
+				target_symbol_id: "123e4567-e89b-42d3-a456-426614174102"
+			}
+		]);
+		db.explorationObservations.upsertMany(OWNER, REPO, [
+			{
+				subject: "Compiler evidence",
+				fact: "Context is packed under a deterministic token budget.",
+				confidence: 0.95,
+				evidence: [{ file_path: "src/compiler.ts", symbol_id: "123e4567-e89b-42d3-a456-426614174101" }]
+			}
+		]);
+
+		const result = getStructured(
+			await handleAgentContext(
+				{
+					owner: OWNER,
+					repo: REPO,
+					objective: "compiler",
+					current_file_path: "src/compiler.ts",
+					sources: ["handoffs", "standards", "observations", "code"],
+					budget: { tokens: 2000, max_items: 20, code_depth: 1 },
+					json: true
+				},
+				db,
+				vectors
+			)
+		);
+
+		expect(new Set(result.context.map((item) => item.source))).toEqual(
+			new Set(["handoffs", "standards", "observations", "code"])
+		);
+		expect(result.context.filter((item) => item.source === "code").map((item) => item.id)).toContain(
+			"123e4567-e89b-42d3-a456-426614174102"
+		);
+	});
+
+	it("ranks objective matches found in an observation fact, not only its subject", async () => {
+		db.explorationObservations.upsertMany(OWNER, REPO, [
+			{
+				subject: "Unrelated heading",
+				fact: "The compiler uses a needle-fact token allocator.",
+				confidence: 0.9,
+				evidence: [{ file_path: "src/not-indexed.ts" }]
+			}
+		]);
+
+		const result = getStructured(
+			await handleAgentContext(
+				{
+					owner: OWNER,
+					repo: REPO,
+					objective: "needle-fact",
+					sources: ["observations"],
+					include_stale: true,
+					json: true
+				},
+				db,
+				vectors
+			)
+		);
+
+		expect(result.context.map((item) => item.source)).toEqual(["observations"]);
 	});
 
 	// ─── limit param ─────────────────────────────────────────────────────
@@ -263,58 +472,5 @@ describe("Agent Context - handleAgentContext", () => {
 		const res = await handleAgentContext({ owner: OWNER, repo: REPO, limit: 3, json: true }, db, vectors);
 
 		expect(getStructured(res).memories.length).toBeLessThanOrEqual(3);
-	});
-});
-
-describe("Agent Context - Schema Validation (AgentContextSchema)", () => {
-	it("should reject empty owner", () => {
-		expect(() => AgentContextSchema.parse({ owner: "", repo: "test" })).toThrow();
-	});
-
-	it("should reject empty repo", () => {
-		expect(() => AgentContextSchema.parse({ owner: "test", repo: "" })).toThrow();
-	});
-
-	it("should accept query as optional string", () => {
-		const result = AgentContextSchema.parse({ owner: "test", repo: "test", query: "search term" });
-		expect(result.query).toBe("search term");
-	});
-
-	it("should accept search via query field", () => {
-		const result = AgentContextSchema.parse({
-			owner: "test",
-			repo: "test",
-			query: "old search"
-		});
-		expect(result.query).toBe("old search");
-	});
-
-	it("should apply default limit of 5", () => {
-		const result = AgentContextSchema.parse({ owner: "test", repo: "test" });
-		expect(result.limit).toBe(5);
-	});
-
-	it("should apply default json false", () => {
-		const result = AgentContextSchema.parse({ owner: "test", repo: "test" });
-		expect(result.json).toBe(false);
-	});
-});
-
-describe("Agent Context - decision-log and session-summarize removed", () => {
-	it("decision-log/session-summarize logic replaced by flat fields in memory-write", () => {
-		// Verify the flat decision fields exist on memory-write schema
-		const shape = MemoryWriteSchema.shape || {};
-		const keys = Object.keys(shape);
-		expect(keys).toContain("context");
-		expect(keys).toContain("rationale");
-		expect(keys).toContain("alternatives");
-		expect(keys).toContain("key_decisions");
-		expect(keys).toContain("next_steps");
-	});
-
-	it("agent-context definition no longer lists decision-log or session-summarize tools", () => {
-		const toolNames = AGENT_TOOL_DEFINITIONS.map((t: { name: string }) => t.name);
-		expect(toolNames).not.toContain("decision-log");
-		expect(toolNames).not.toContain("session-summarize");
 	});
 });

--- a/src/mcp/tests/backward-compat.test.ts
+++ b/src/mcp/tests/backward-compat.test.ts
@@ -129,5 +129,7 @@ describe("ADR Backward Compat Aliases — old names route to new handlers", () =
 		expect(names).toContain("memory-write");
 		expect(names).toContain("memory-read");
 		expect(names).toContain("task-write");
+		expect(names).toContain("observation-write");
+		expect(names).toContain("observation-read");
 	});
 });

--- a/src/mcp/tests/codebase-index/architecture.test.ts
+++ b/src/mcp/tests/codebase-index/architecture.test.ts
@@ -317,7 +317,7 @@ describe("ARCHITECTURE doc_comment text surface (TASK-460)", () => {
 			{ repo, file_path: "src/a.ts", name: "PlainExport", kind: "function", exported: true, start_line: 5 }
 		]);
 		const res = await handleCodebaseRead(
-			{ repo, owner: "vheins", includeSymbolCounts: true },
+			{ repo, owner: "vheins", json: true, includeSymbolCounts: true },
 			store as unknown as never,
 			vectors as never
 		);

--- a/src/mcp/tests/codebase-index/codebase-read-matchkind.test.ts
+++ b/src/mcp/tests/codebase-index/codebase-read-matchkind.test.ts
@@ -101,7 +101,11 @@ describe("handleCodebaseRead SEARCH — matchKind / related / scope (issue #81)"
 	});
 
 	it('(a) Markdown heading results carry matchKind "documentation"', async () => {
-		const response = await handleCodebaseRead({ query: "Models", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ query: "Models", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		const symbols = data.symbols as Array<Record<string, unknown>>;
 
@@ -112,7 +116,7 @@ describe("handleCodebaseRead SEARCH — matchKind / related / scope (issue #81)"
 
 	it('(b) real source symbols carry matchKind "source"', async () => {
 		const response = await handleCodebaseRead(
-			{ query: "createUser", repo: "test-repo", owner: "vheins" },
+			{ query: "createUser", repo: "test-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -129,7 +133,11 @@ describe("handleCodebaseRead SEARCH — matchKind / related / scope (issue #81)"
 		// "Models" matches the heading (Vheins\Common\Models) via FTS, and the
 		// heading's extracted token lookup finds the User class in
 		// modules/Common/Models/User.php.
-		const response = await handleCodebaseRead({ query: "Models", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ query: "Models", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		const related = data.related as Array<Record<string, unknown>>;
 
@@ -143,7 +151,7 @@ describe("handleCodebaseRead SEARCH — matchKind / related / scope (issue #81)"
 
 	it("(d) SEARCH envelope exposes repoRoot and a scope count (files/symbols) for the repo", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "Models", repo: "test-repo", owner: "vheins", repoPath: "/abs/path/to/test-repo" },
+			{ query: "Models", repo: "test-repo", owner: "vheins", json: true, repoPath: "/abs/path/to/test-repo" },
 			store,
 			vectors
 		);

--- a/src/mcp/tests/codebase-index/codebase-read-range.test.ts
+++ b/src/mcp/tests/codebase-index/codebase-read-range.test.ts
@@ -163,7 +163,7 @@ afterAll(() => {
 });
 
 async function readRange(extra: Record<string, unknown>): Promise<McpResponse> {
-	return handleCodebaseRead({ owner: "vheins", repo: REPO, filePath: FILE, ...extra }, store, vectors);
+	return handleCodebaseRead({ owner: "vheins", json: true, repo: REPO, filePath: FILE, ...extra }, store, vectors);
 }
 
 describe("codebase-read FILE mode — range awareness (#88 / TASK-014)", () => {

--- a/src/mcp/tests/codebase-index/get-file-symbols.test.ts
+++ b/src/mcp/tests/codebase-index/get-file-symbols.test.ts
@@ -104,7 +104,7 @@ describe("handleCodebaseRead (file mode)", () => {
 			}
 		]);
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo, filePath }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo, filePath }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.file).toBeDefined();
@@ -144,7 +144,7 @@ describe("handleCodebaseRead (file mode)", () => {
 		const repo = "test-repo";
 		const filePath = "src/ghost.ts";
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo, filePath }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo, filePath }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.error).toBe("File not indexed. Run index_repository first.");
@@ -161,7 +161,7 @@ describe("handleCodebaseRead (file mode)", () => {
 			{ repo: repoA, file_path: filePath, name: "sharedFn", kind: "function", start_line: 1, end_line: 5 }
 		]);
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo: repoB, filePath }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo: repoB, filePath }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.error).toBe("File not indexed. Run index_repository first.");
@@ -202,7 +202,7 @@ describe("handleCodebaseRead (file mode)", () => {
 			}
 		]);
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo, filePath }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo, filePath }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.total).toBe(2);
@@ -223,7 +223,7 @@ describe("handleCodebaseRead (file mode)", () => {
 
 		seedFile(store, repo, filePath);
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo, filePath }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo, filePath }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.file).toBeDefined();
@@ -232,7 +232,7 @@ describe("handleCodebaseRead (file mode)", () => {
 	});
 
 	it("returns REPO_REQUIRED structured response on missing repo param", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", filePath: "src/test.ts" }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, filePath: "src/test.ts" }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.code).toBe("REPO_REQUIRED");
@@ -242,7 +242,7 @@ describe("handleCodebaseRead (file mode)", () => {
 	it("returns REPO_REQUIRED structured response on missing filePath param", async () => {
 		// Without filePath, it falls into status mode (no error), but with filePath it's file mode.
 		// File mode without repo returns a structured REPO_REQUIRED response.
-		const response = await handleCodebaseRead({ owner: "vheins", filePath: "src/test.ts" }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, filePath: "src/test.ts" }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.code).toBe("REPO_REQUIRED");
@@ -251,12 +251,16 @@ describe("handleCodebaseRead (file mode)", () => {
 
 	it("throws on empty repo", async () => {
 		await expect(
-			handleCodebaseRead({ owner: "vheins", repo: "", filePath: "src/test.ts" }, store, vectors)
+			handleCodebaseRead({ owner: "vheins", json: true, repo: "", filePath: "src/test.ts" }, store, vectors)
 		).rejects.toThrow();
 	});
 
 	it("falls back to architecture mode when filePath is empty", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", repo: "test-repo", filePath: "" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: "test-repo", filePath: "" },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		expect(data.mode).toBe("architecture");
 	});
@@ -278,7 +282,7 @@ describe("handleCodebaseRead (file mode)", () => {
 			},
 			{ repo, file_path: filePath, name: "plainFn", kind: "function", start_line: 10, end_line: 12 }
 		]);
-		const res = await handleCodebaseRead({ owner: "vheins", repo, filePath }, store, vectors);
+		const res = await handleCodebaseRead({ owner: "vheins", json: true, repo, filePath }, store, vectors);
 		const text = getPrimaryTextContent(res);
 		expect(text).toMatch(/doccedFn/);
 		expect(text).toMatch(/Does the thing/);

--- a/src/mcp/tests/codebase-index/indexing-writer.test.ts
+++ b/src/mcp/tests/codebase-index/indexing-writer.test.ts
@@ -352,4 +352,72 @@ describe("indexing-writer", () => {
 			(store.db.prepare("SELECT COUNT(*) as cnt FROM entities WHERE name = 'renamedSym'").get() as { cnt: number }).cnt
 		).toBe(0);
 	});
+
+	it("indexing lifecycle keeps exploration observations honest: reindex, rename, and delete (issue #92)", async () => {
+		const store = await makeStore();
+		const repo = "test-repo";
+		const owner = "test-owner";
+
+		// Index a file with a symbol, then publish an observation against it.
+		expect(
+			await writeParseBatch(
+				base(store, repo),
+				[{ repo, file_path: "svc.ts", checksum: "checksum-a" }],
+				[{ id: "123e4567-e89b-42d3-a456-426614174001", repo, file_path: "svc.ts", name: "run", kind: "function" }],
+				new Map()
+			)
+		).toBe(0);
+		const created = store.explorationObservations.upsertMany(owner, repo, [
+			{
+				subject: "run",
+				fact: "The run function performs the operation.",
+				confidence: 0.9,
+				evidence: [{ file_path: "svc.ts", symbol_id: "123e4567-e89b-42d3-a456-426614174001" }]
+			}
+		])[0]!.observation;
+		expect(created.freshness).toBe("valid");
+
+		// An unrelated file's re-index must not touch the observation.
+		expect(
+			await writeParseBatch(
+				base(store, repo),
+				[{ repo, file_path: "other.ts", checksum: "other-a" }],
+				[{ repo, file_path: "other.ts", name: "other", kind: "function" }],
+				new Map()
+			)
+		).toBe(0);
+		expect(store.explorationObservations.getById(owner, repo, created.id)!.freshness).toBe("valid");
+
+		// Re-indexing the referenced file with a CHANGED symbol marks it stale.
+		expect(
+			await writeParseBatch(
+				base(store, repo),
+				[{ repo, file_path: "svc.ts", checksum: "checksum-b" }],
+				[
+					{
+						id: "123e4567-e89b-42d3-a456-426614174002",
+						repo,
+						file_path: "svc.ts",
+						name: "run",
+						kind: "function",
+						signature: "run(input: string): void"
+					}
+				],
+				new Map()
+			)
+		).toBe(0);
+		expect(store.explorationObservations.getById(owner, repo, created.id)!.freshness).toBe("stale");
+
+		// A rename carries the evidence pointer to the new path.
+		expect(await applyRenames(base(store, repo), new Map([["renamed.ts", "svc.ts"]]))).toBe(0);
+		expect(store.explorationObservations.getById(owner, repo, created.id, true)!.evidence![0].file_path).toBe(
+			"renamed.ts"
+		);
+
+		// Deleting the source marks the observation stale with a delete reason.
+		expect(await cleanStaleFiles(base(store, repo), new Set(["renamed.ts"]))).toBe(0);
+		const afterDelete = store.explorationObservations.getById(owner, repo, created.id)!;
+		expect(afterDelete.freshness).toBe("stale");
+		expect(afterDelete.stale_reason).toBe("file_deleted");
+	});
 });

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.architecture.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.architecture.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
 
 describe("handleCodebaseRead (architecture mode)", () => {
 	it("returns directory tree with correct depth", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, depth: 2 }, store, vectors);
+		const resp = await handleCodebaseRead({ owner: "vheins", json: true, repo: REPO, depth: 2 }, store, vectors);
 		const d = data(resp);
 
 		// Root
@@ -45,7 +45,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 	});
 
 	it("symbol counts are accurate", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, depth: 2 }, store, vectors);
+		const resp = await handleCodebaseRead({ owner: "vheins", json: true, repo: REPO, depth: 2 }, store, vectors);
 		const d = data(resp);
 
 		const summary = d.summary as Record<string, unknown>;
@@ -58,7 +58,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 	});
 
 	it("language breakdown shows TypeScript and TSX", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, depth: 2 }, store, vectors);
+		const resp = await handleCodebaseRead({ owner: "vheins", json: true, repo: REPO, depth: 2 }, store, vectors);
 		const d = data(resp);
 
 		const summary = d.summary as Record<string, unknown>;

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.code.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.code.test.ts
@@ -171,8 +171,8 @@ describe("handleCodebaseRead (code mode)", () => {
 		const resp = await handleCodebaseRead({ owner: "vheins", repo: CODE_REPO, content: "greet" }, store, vectors);
 		const d = data(resp);
 
-		expect(d.code).toBe("REPO_PATH_REQUIRED");
-		expect(d.error).toBeDefined();
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({ schema: "tool-error", code: "REPO_PATH_REQUIRED", retryable: false });
 	});
 
 	it("non-existent repoPath → REPO_PATH_NOT_FOUND", async () => {
@@ -183,7 +183,8 @@ describe("handleCodebaseRead (code mode)", () => {
 		);
 		const d = data(resp);
 
-		expect(d.code).toBe("REPO_PATH_NOT_FOUND");
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({ schema: "tool-error", code: "REPO_PATH_NOT_FOUND", retryable: false });
 	});
 
 	it("unindexed repo → REPO_NOT_INDEXED", async () => {
@@ -194,7 +195,8 @@ describe("handleCodebaseRead (code mode)", () => {
 		);
 		const d = data(resp);
 
-		expect(d.code).toBe("REPO_NOT_INDEXED");
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({ schema: "tool-error", code: "REPO_NOT_INDEXED", retryable: false });
 	});
 
 	it("invalid regex → INVALID_REGEX", async () => {
@@ -205,6 +207,7 @@ describe("handleCodebaseRead (code mode)", () => {
 		);
 		const d = data(resp);
 
-		expect(d.code).toBe("INVALID_REGEX");
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({ schema: "tool-error", code: "INVALID_REGEX", retryable: false });
 	});
 });

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.code.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.code.test.ts
@@ -83,7 +83,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("greps indexed file contents with enclosing-symbol enrichment", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "greet", repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "greet", repoPath: tempDir },
 			store,
 			vectors
 		);
@@ -128,7 +128,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("respects the language filter (no files of that language → empty result)", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "greet", language: "markdown", repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "greet", language: "markdown", repoPath: tempDir },
 			store,
 			vectors
 		);
@@ -142,7 +142,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("applies the code-mode default limit and pagination", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "greet", limit: 2, repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "greet", limit: 2, repoPath: tempDir },
 			store,
 			vectors
 		);
@@ -156,7 +156,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("empty content is a no-op (code mode, empty result — never a full dump)", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "", repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "", repoPath: tempDir },
 			store,
 			vectors
 		);
@@ -168,7 +168,11 @@ describe("handleCodebaseRead (code mode)", () => {
 	});
 
 	it("missing repoPath → REPO_PATH_REQUIRED", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: CODE_REPO, content: "greet" }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "greet" },
+			store,
+			vectors
+		);
 		const d = data(resp);
 
 		expect(resp.isError).toBe(true);
@@ -177,7 +181,13 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("non-existent repoPath → REPO_PATH_NOT_FOUND", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "greet", repoPath: path.join(tempDir, "does-not-exist") },
+			{
+				owner: "vheins",
+				json: true,
+				repo: CODE_REPO,
+				content: "greet",
+				repoPath: path.join(tempDir, "does-not-exist")
+			},
 			store,
 			vectors
 		);
@@ -189,7 +199,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("unindexed repo → REPO_NOT_INDEXED", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: "never-indexed", content: "x", repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: "never-indexed", content: "x", repoPath: tempDir },
 			store,
 			vectors
 		);
@@ -201,7 +211,7 @@ describe("handleCodebaseRead (code mode)", () => {
 
 	it("invalid regex → INVALID_REGEX", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", repo: CODE_REPO, content: "[", regex: true, repoPath: tempDir },
+			{ owner: "vheins", json: true, repo: CODE_REPO, content: "[", regex: true, repoPath: tempDir },
 			store,
 			vectors
 		);

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.file.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.file.test.ts
@@ -19,7 +19,11 @@ afterAll(() => {
 
 describe("handleCodebaseRead (file mode)", () => {
 	it("returns all symbols in a known file", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, filePath: "index.ts" }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: REPO, filePath: "index.ts" },
+			store,
+			vectors
+		);
 		const d = data(resp);
 
 		expect(d.error).toBeUndefined();
@@ -40,7 +44,11 @@ describe("handleCodebaseRead (file mode)", () => {
 	});
 
 	it("returns symbols in declaration order (by start_line)", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, filePath: "index.ts" }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: REPO, filePath: "index.ts" },
+			store,
+			vectors
+		);
 		const d = data(resp);
 		const symbols = d.symbols as Array<Record<string, unknown>>;
 
@@ -53,7 +61,11 @@ describe("handleCodebaseRead (file mode)", () => {
 	});
 
 	it("returns error for non-indexed file", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", repo: REPO, filePath: "nonexistent.ts" }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: REPO, filePath: "nonexistent.ts" },
+			store,
+			vectors
+		);
 		const d = data(resp);
 
 		expect(d.error).toBe("File not indexed. Run index_repository first.");

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.search-symbols.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.search-symbols.test.ts
@@ -19,7 +19,11 @@ afterAll(() => {
 
 describe("handleCodebaseRead (search_symbols mode)", () => {
 	it("returns correct symbol for exact name match", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", query: "initializeApp", repo: REPO }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, query: "initializeApp", repo: REPO },
+			store,
+			vectors
+		);
 		const d = data(resp);
 		const symbols = d.symbols as Array<Record<string, unknown>>;
 
@@ -30,7 +34,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("returns multiple ranked results for prefix query", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", query: "App", repo: REPO }, store, vectors);
+		const resp = await handleCodebaseRead({ owner: "vheins", json: true, query: "App", repo: REPO }, store, vectors);
 		const d = data(resp);
 		const symbols = d.symbols as Array<Record<string, unknown>>;
 
@@ -49,7 +53,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("kind filter returns only matching kind", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", query: "form", repo: REPO, kind: "function" },
+			{ owner: "vheins", json: true, query: "form", repo: REPO, kind: "function" },
 			store,
 			vectors
 		);
@@ -64,7 +68,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("returns empty result for non-existent symbol", async () => {
 		const resp = await handleCodebaseRead(
-			{ owner: "vheins", query: "zzzNonexistentSymbol", repo: REPO },
+			{ owner: "vheins", json: true, query: "zzzNonexistentSymbol", repo: REPO },
 			store,
 			vectors
 		);
@@ -78,7 +82,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	it("pagination: limit + offset works correctly", async () => {
 		// Get page 1: limit 3
 		const page1 = await handleCodebaseRead(
-			{ owner: "vheins", query: "a", repo: REPO, limit: 3, offset: 0 },
+			{ owner: "vheins", json: true, query: "a", repo: REPO, limit: 3, offset: 0 },
 			store,
 			vectors
 		);
@@ -88,7 +92,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 		// Get page 2: offset 3, limit 3
 		const page2 = await handleCodebaseRead(
-			{ owner: "vheins", query: "a", repo: REPO, limit: 3, offset: 3 },
+			{ owner: "vheins", json: true, query: "a", repo: REPO, limit: 3, offset: 3 },
 			store,
 			vectors
 		);

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.trace.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.trace.test.ts
@@ -59,9 +59,9 @@ describe("handleCodebaseRead (trace mode)", () => {
 		const resp = await handleCodebaseRead({ owner: "vheins", name: "Button", repo: REPO }, store, vectors);
 		const d = data(resp);
 
-		expect(d.code).toBe("AMBIGUOUS_SYMBOL");
-		expect(d.disambiguation).toBeDefined();
-		const disamb = d.disambiguation as Array<Record<string, unknown>>;
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({ schema: "tool-error", code: "AMBIGUOUS_SYMBOL", retryable: false });
+		const disamb = (d.details as Record<string, unknown>).disambiguation as Array<Record<string, unknown>>;
 		expect(disamb.length).toBe(2);
 
 		const names = disamb.map((s) => s.name);
@@ -183,9 +183,13 @@ describe("handleCodebaseRead (trace mode)", () => {
 		const resp = await handleCodebaseRead({ owner: "vheins", name: "zzzNonexistentFn", repo: REPO }, store, vectors);
 		const d = data(resp);
 
-		expect(d.code).toBe("SYMBOL_NOT_FOUND");
-		expect(d.error).toBeDefined();
-		expect(d.error).toContain("not found");
+		expect(resp.isError).toBe(true);
+		expect(d).toMatchObject({
+			schema: "tool-error",
+			code: "SYMBOL_NOT_FOUND",
+			retryable: false,
+			message: expect.stringContaining("not found")
+		});
 	});
 });
 

--- a/src/mcp/tests/codebase-index/mcp-tools.integration.trace.test.ts
+++ b/src/mcp/tests/codebase-index/mcp-tools.integration.trace.test.ts
@@ -19,7 +19,11 @@ afterAll(() => {
 
 describe("handleCodebaseRead (trace mode)", () => {
 	it("returns definition for a known exported function", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", name: "formatSize", repo: REPO }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, name: "formatSize", repo: REPO },
+			store,
+			vectors
+		);
 		const d = data(resp);
 
 		expect(d.symbol).toBeDefined();
@@ -56,7 +60,7 @@ describe("handleCodebaseRead (trace mode)", () => {
 			}
 		]);
 
-		const resp = await handleCodebaseRead({ owner: "vheins", name: "Button", repo: REPO }, store, vectors);
+		const resp = await handleCodebaseRead({ owner: "vheins", json: true, name: "Button", repo: REPO }, store, vectors);
 		const d = data(resp);
 
 		expect(resp.isError).toBe(true);
@@ -180,7 +184,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 	});
 
 	it("returns error for non-existent symbol", async () => {
-		const resp = await handleCodebaseRead({ owner: "vheins", name: "zzzNonexistentFn", repo: REPO }, store, vectors);
+		const resp = await handleCodebaseRead(
+			{ owner: "vheins", json: true, name: "zzzNonexistentFn", repo: REPO },
+			store,
+			vectors
+		);
 		const d = data(resp);
 
 		expect(resp.isError).toBe(true);

--- a/src/mcp/tests/codebase-index/search-symbols.test.ts
+++ b/src/mcp/tests/codebase-index/search-symbols.test.ts
@@ -126,7 +126,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("returns exact match when searching by exact name", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "createUser", repo: "test-repo", owner: "vheins" },
+			{ query: "createUser", repo: "test-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -141,7 +141,11 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("returns prefix-ranked results for partial name search", async () => {
-		const response = await handleCodebaseRead({ query: "create", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ query: "create", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		const symbols = data.symbols as Array<Record<string, unknown>>;
 
@@ -152,7 +156,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("filters by kind", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "User", repo: "test-repo", owner: "vheins", kind: "class" },
+			{ query: "User", repo: "test-repo", owner: "vheins", json: true, kind: "class" },
 			store,
 			vectors
 		);
@@ -166,7 +170,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("scopes results to the specified repo", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "createUser", repo: "other-repo", owner: "vheins" },
+			{ query: "createUser", repo: "other-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -178,7 +182,11 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("returns empty for queries under 2 characters", async () => {
-		const response = await handleCodebaseRead({ query: "c", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ query: "c", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		const symbols = data.symbols as Array<Record<string, unknown>>;
 
@@ -187,7 +195,11 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("returns empty for empty query string", async () => {
-		const response = await handleCodebaseRead({ query: "", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ query: "", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.total as number).toBe(0);
@@ -195,7 +207,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("supports pagination with offset and limit", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "User", repo: "test-repo", owner: "vheins", limit: 2, offset: 1 },
+			{ query: "User", repo: "test-repo", owner: "vheins", json: true, limit: 2, offset: 1 },
 			store,
 			vectors
 		);
@@ -209,7 +221,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 		// Second page should start at offset 3
 		const response2 = await handleCodebaseRead(
-			{ query: "User", repo: "test-repo", owner: "vheins", limit: 2, offset: 3 },
+			{ query: "User", repo: "test-repo", owner: "vheins", json: true, limit: 2, offset: 3 },
 			store,
 			vectors
 		);
@@ -228,7 +240,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("returns empty result for non-existent symbol", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "NonExistentSymbol", repo: "test-repo", owner: "vheins" },
+			{ query: "NonExistentSymbol", repo: "test-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -241,7 +253,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("filters by exportedOnly", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "Process", repo: "test-repo", owner: "vheins", exportedOnly: true },
+			{ query: "Process", repo: "test-repo", owner: "vheins", json: true, exportedOnly: true },
 			store,
 			vectors
 		);
@@ -256,7 +268,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("searches across repos when `repos` is provided without `repo`", async () => {
 		const response = await handleCodebaseRead(
-			{ query: "createUser", repos: ["test-repo", "other-repo"], owner: "vheins" },
+			{ query: "createUser", repos: ["test-repo", "other-repo"], owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -275,7 +287,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("rejects SEARCH when both `repo` and `repos` are absent (cross-tenant guard)", async () => {
-		const response = await handleCodebaseRead({ query: "createUser", owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead({ query: "createUser", owner: "vheins", json: true }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.code).toBe("REPO_REQUIRED");
@@ -285,7 +297,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	it("keeps single-repo search working (backward compat) and lets `repos` win over `repo`", async () => {
 		// `repo` alone still scopes to one repo (backward compatible).
 		const single = await handleCodebaseRead(
-			{ query: "createUser", repo: "test-repo", owner: "vheins" },
+			{ query: "createUser", repo: "test-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -299,7 +311,7 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 		// When both are provided, `repos` governs — a session-injected `repo`
 		// must not narrow an explicit cross-repo scope.
 		const both = await handleCodebaseRead(
-			{ query: "createUser", repo: "test-repo", repos: ["other-repo"], owner: "vheins" },
+			{ query: "createUser", repo: "test-repo", repos: ["other-repo"], owner: "vheins", json: true },
 			store,
 			vectors
 		);
@@ -313,13 +325,17 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 
 	it("SEARCH text includes doc_comment per match and omits it when absent (TASK-460)", async () => {
 		const { getPrimaryTextContent } = await import("../../utils/mcp-response.js");
-		const res = await handleCodebaseRead({ query: "createUser", repo: "test-repo", owner: "vheins" }, store, vectors);
+		const res = await handleCodebaseRead(
+			{ query: "createUser", repo: "test-repo", owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const text = getPrimaryTextContent(res);
 		// createUser has doc_comment "Creates a new user" — surfaced as suffix in text lines.
 		expect(text).toMatch(/Creates a new user/);
 		// internalHelper has no doc_comment — its SEARCH line must not have " — " suffix.
 		const internalRes = await handleCodebaseRead(
-			{ query: "internalHelper", repo: "test-repo", owner: "vheins" },
+			{ query: "internalHelper", repo: "test-repo", owner: "vheins", json: true },
 			store,
 			vectors
 		);

--- a/src/mcp/tests/codebase-index/semantic-adapters.test.ts
+++ b/src/mcp/tests/codebase-index/semantic-adapters.test.ts
@@ -195,6 +195,8 @@ describe("no-adapter fallback", () => {
 		expect(result.failedFiles).toBe(0);
 		expect(result.errors).toHaveLength(0);
 		expect(result.semanticEnriched).toBe(0);
+		const stored = db.codebaseSymbols.getSymbolsByFile("repo", "src/Model.php")[0];
+		expect(stored.source_fingerprint).toMatch(/^[a-f0-9]{64}$/);
 	});
 });
 

--- a/src/mcp/tests/codebase-index/tools.test.ts
+++ b/src/mcp/tests/codebase-index/tools.test.ts
@@ -61,36 +61,38 @@ describe("IndexRepoSchema", () => {
 	});
 
 	it("rejects empty repo", () => {
-		expect(() => IndexRepoSchema.parse({ owner: "vheins", repo: "", repoPath: "/tmp" })).toThrow();
+		expect(() => IndexRepoSchema.parse({ owner: "vheins", json: true, repo: "", repoPath: "/tmp" })).toThrow();
 	});
 
 	it("rejects empty repoPath", () => {
-		expect(() => IndexRepoSchema.parse({ owner: "vheins", repo: "test", repoPath: "" })).toThrow();
+		expect(() => IndexRepoSchema.parse({ owner: "vheins", json: true, repo: "test", repoPath: "" })).toThrow();
 	});
 
 	it("rejects missing repoPath entirely", () => {
-		expect(() => IndexRepoSchema.parse({ owner: "vheins", repo: "test" })).toThrow();
+		expect(() => IndexRepoSchema.parse({ owner: "vheins", json: true, repo: "test" })).toThrow();
 	});
 
 	it("rejects wrong type for force", () => {
-		expect(() => IndexRepoSchema.parse({ owner: "vheins", repo: "test", repoPath: "/tmp", force: "yes" })).toThrow();
+		expect(() =>
+			IndexRepoSchema.parse({ owner: "vheins", json: true, repo: "test", repoPath: "/tmp", force: "yes" })
+		).toThrow();
 	});
 });
 
 describe("IndexStatusSchema", () => {
 	it("validates a complete input", () => {
-		const result = IndexStatusSchema.parse({ owner: "vheins", repo: "test-repo" });
+		const result = IndexStatusSchema.parse({ owner: "vheins", json: true, repo: "test-repo" });
 		expect(result.repo).toBe("test-repo");
 	});
 
 	it("validates with optional repoPath", () => {
-		const result = IndexStatusSchema.parse({ owner: "vheins", repo: "test-repo", repoPath: "/tmp/repo" });
+		const result = IndexStatusSchema.parse({ owner: "vheins", json: true, repo: "test-repo", repoPath: "/tmp/repo" });
 		expect(result.repo).toBe("test-repo");
 		expect(result.repoPath).toBe("/tmp/repo");
 	});
 
 	it("rejects empty repo", () => {
-		expect(() => IndexStatusSchema.parse({ owner: "vheins", repo: "" })).toThrow();
+		expect(() => IndexStatusSchema.parse({ owner: "vheins", json: true, repo: "" })).toThrow();
 	});
 
 	it("rejects missing repo", () => {
@@ -110,7 +112,7 @@ describe("handleCodebaseIndex (write)", () => {
 	it("returns input validation error for missing repoPath", async () => {
 		const store = await createTestStore();
 		try {
-			const response = await handleCodebaseIndex({ owner: "vheins", repo: "test-repo" }, store, vectors);
+			const response = await handleCodebaseIndex({ owner: "vheins", json: true, repo: "test-repo" }, store, vectors);
 			expect(response).toBeDefined();
 		} catch (err: unknown) {
 			expect((err as Error).message).toContain("repoPath");
@@ -123,7 +125,7 @@ describe("handleCodebaseIndex (write)", () => {
 		const store = await createTestStore();
 		try {
 			const response = await handleCodebaseIndex(
-				{ owner: "vheins", repo: "test-repo", repoPath: "/nonexistent/path/abc123xyz" },
+				{ owner: "vheins", json: true, repo: "test-repo", repoPath: "/nonexistent/path/abc123xyz" },
 				store,
 				vectors
 			);
@@ -145,7 +147,7 @@ describe("handleCodebaseIndex (write)", () => {
 
 		try {
 			const response = await handleCodebaseIndex(
-				{ owner: "vheins", repo: "test-repo", repoPath: tmpFile },
+				{ owner: "vheins", json: true, repo: "test-repo", repoPath: tmpFile },
 				store,
 				vectors
 			);
@@ -176,7 +178,7 @@ describe("handleCodebaseRead (status mode)", () => {
 	});
 
 	it("returns architecture with zero files for an unindexed repo", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", repo: "unknown-repo" }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo: "unknown-repo" }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 		expect(data.mode).toBe("architecture");
 		const summary = data.summary as Record<string, number>;
@@ -189,8 +191,17 @@ describe("handleCodebaseRead (status mode)", () => {
 		expect(response).toBeDefined();
 	});
 
+	it("keeps default mode text-only and exposes stable discriminators in structured mode", async () => {
+		const text = await handleCodebaseRead({ repo: "test-repo" }, store, vectors);
+		expect(text.structuredContent).toBeUndefined();
+		expect(text.content?.[0]).toMatchObject({ type: "text" });
+
+		const structured = await handleCodebaseRead({ repo: "test-repo", json: true }, store, vectors);
+		expect(structured.structuredContent).toMatchObject({ schema: "codebase-read", mode: "architecture" });
+	});
+
 	it("throws on empty repo", async () => {
-		await expect(handleCodebaseRead({ owner: "vheins", repo: "" }, store, vectors)).rejects.toThrow();
+		await expect(handleCodebaseRead({ owner: "vheins", json: true, repo: "" }, store, vectors)).rejects.toThrow();
 	});
 });
 
@@ -227,7 +238,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 			size_bytes: 200
 		});
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo: "repo", depth: 3 }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo: "repo", depth: 3 }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.root).toBeDefined();
@@ -237,7 +248,11 @@ describe("handleCodebaseRead (architecture mode)", () => {
 	});
 
 	it("returns empty architecture for unindexed repo", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", repo: "never-indexed", depth: 3 }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ owner: "vheins", json: true, repo: "never-indexed", depth: 3 },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		const summary = data.summary as Record<string, unknown>;
 		expect(summary.totalFiles).toBe(0);
@@ -267,7 +282,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 		]);
 
 		const response = await handleCodebaseRead(
-			{ owner: "vheins", repo: "repo", depth: 3, includeSymbolCounts: true },
+			{ owner: "vheins", json: true, repo: "repo", depth: 3, includeSymbolCounts: true },
 			store,
 			vectors
 		);
@@ -314,7 +329,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 			{ repo: "repo", symbol_name: "usedFn", caller_file: "src/app.ts", caller_line: 14, kind: "import" }
 		]);
 
-		const response = await handleCodebaseRead({ owner: "vheins", repo: "repo", depth: 3 }, store, vectors);
+		const response = await handleCodebaseRead({ owner: "vheins", json: true, repo: "repo", depth: 3 }, store, vectors);
 		const data = response.structuredContent as Record<string, unknown>;
 		const deadCode = data.deadCode as Record<string, unknown>;
 
@@ -347,7 +362,7 @@ describe("handleCodebaseRead (architecture mode)", () => {
 		});
 
 		const response = await handleCodebaseRead(
-			{ owner: "vheins", repo: "repo", depth: 3, includeSymbolCounts: false },
+			{ owner: "vheins", json: true, repo: "repo", depth: 3, includeSymbolCounts: false },
 			store,
 			vectors
 		);
@@ -394,7 +409,7 @@ describe("handleCodebaseRead (file mode)", () => {
 		]);
 
 		const response = await handleCodebaseRead(
-			{ owner: "vheins", repo: "repo", filePath: "src/auth.ts" },
+			{ owner: "vheins", json: true, repo: "repo", filePath: "src/auth.ts" },
 			store,
 			vectors
 		);
@@ -408,7 +423,7 @@ describe("handleCodebaseRead (file mode)", () => {
 
 	it("returns FILE_NOT_INDEXED for unknown file", async () => {
 		const response = await handleCodebaseRead(
-			{ owner: "vheins", repo: "repo", filePath: "src/ghost.ts" },
+			{ owner: "vheins", json: true, repo: "repo", filePath: "src/ghost.ts" },
 			store,
 			vectors
 		);
@@ -439,21 +454,33 @@ describe("handleCodebaseRead (search_symbols mode)", () => {
 	});
 
 	it("returns empty for short query (1 character)", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", query: "a", repo: "test-repo" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ owner: "vheins", json: true, query: "a", repo: "test-repo" },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		expect(data.total).toBe(0);
 		expect(data.hasMore).toBe(false);
 	});
 
 	it("returns empty for empty query", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", query: "", repo: "test-repo" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ owner: "vheins", json: true, query: "", repo: "test-repo" },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		expect(data.total).toBe(0);
 		expect(data.hasMore).toBe(false);
 	});
 
 	it("returns empty for whitespace query", async () => {
-		const response = await handleCodebaseRead({ owner: "vheins", query: "  ", repo: "test-repo" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ owner: "vheins", json: true, query: "  ", repo: "test-repo" },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 		expect(data.total).toBe(0);
 	});
@@ -473,7 +500,7 @@ describe("handleCodebaseIndexRepository (legacy, still exported)", () => {
 			// Import from codebase-index (hyphenated) where it's actually exported
 			const { handleCodebaseIndexRepository: repoHandler } = await import("../../tools/codebase-index");
 			try {
-				await repoHandler({ owner: "vheins", repo: "test-repo" }, store, vectors);
+				await repoHandler({ owner: "vheins", json: true, repo: "test-repo" }, store, vectors);
 				expect.fail("Should have thrown for missing repoPath");
 			} catch (err: unknown) {
 				expect(err).toBeInstanceOf(ZodError);

--- a/src/mcp/tests/codebase-index/tools.test.ts
+++ b/src/mcp/tests/codebase-index/tools.test.ts
@@ -20,6 +20,7 @@ import { handleCodebaseIndex } from "../../tools/codebase-index-sdk";
 import { handleCodebaseRead } from "../../tools/codebase.read";
 import { createTestStore, SQLiteStore } from "../../storage/sqlite";
 import { VectorStore } from "../../types";
+import { RuntimeCapabilityRegistry, setRuntimeCapabilities } from "../../runtime-capabilities";
 
 // ── No-op vector store for tests that don't need vectors ────────────────
 
@@ -107,6 +108,36 @@ describe("handleCodebaseIndex (write)", () => {
 
 	beforeEach(() => {
 		vectors = noopVectorStore();
+	});
+
+	it("returns runtime capability status without loading the parser", async () => {
+		setRuntimeCapabilities(new RuntimeCapabilityRegistry("balanced"));
+		const store = await createTestStore();
+		try {
+			const response = await handleCodebaseIndex({ owner: "vheins", repo: "test-repo" }, store, vectors);
+			expect(response.structuredContent).toMatchObject({
+				runtime: { profile: "balanced", capabilities: { indexing: { state: "idle" } } }
+			});
+		} finally {
+			store.close();
+			setRuntimeCapabilities(new RuntimeCapabilityRegistry("full"));
+		}
+	});
+
+	it("warms the index capability explicitly through the existing surface", async () => {
+		const registry = new RuntimeCapabilityRegistry("balanced");
+		setRuntimeCapabilities(registry);
+		const store = await createTestStore();
+		try {
+			const response = await handleCodebaseIndex({ owner: "vheins", repo: "test-repo", warmup: true }, store, vectors);
+			expect(response.structuredContent).toMatchObject({
+				profile: "balanced",
+				capabilities: { indexing: { state: "ready" } }
+			});
+		} finally {
+			store.close();
+			setRuntimeCapabilities(new RuntimeCapabilityRegistry("full"));
+		}
 	});
 
 	it("returns input validation error for missing repoPath", async () => {

--- a/src/mcp/tests/codebase-index/tools.test.ts
+++ b/src/mcp/tests/codebase-index/tools.test.ts
@@ -127,9 +127,11 @@ describe("handleCodebaseIndex (write)", () => {
 				store,
 				vectors
 			);
+			expect(response.isError).toBe(true);
 			expect(response.structuredContent).toMatchObject({
-				success: false,
-				error: "PATH_NOT_FOUND"
+				schema: "tool-error",
+				code: "PATH_NOT_FOUND",
+				retryable: false
 			});
 		} finally {
 			store.close();
@@ -147,9 +149,11 @@ describe("handleCodebaseIndex (write)", () => {
 				store,
 				vectors
 			);
+			expect(response.isError).toBe(true);
 			expect(response.structuredContent).toMatchObject({
-				success: false,
-				error: "NOT_A_DIRECTORY"
+				schema: "tool-error",
+				code: "NOT_A_DIRECTORY",
+				retryable: false
 			});
 		} finally {
 			store.close();
@@ -409,8 +413,13 @@ describe("handleCodebaseRead (file mode)", () => {
 			vectors
 		);
 		const data = response.structuredContent as Record<string, unknown>;
-		expect(data.error).toContain("File not indexed");
-		expect(data.code).toBe("FILE_NOT_INDEXED");
+		expect(response.isError).toBe(true);
+		expect(data).toMatchObject({
+			schema: "tool-error",
+			code: "FILE_NOT_INDEXED",
+			retryable: false,
+			message: expect.stringContaining("not indexed")
+		});
 	});
 });
 

--- a/src/mcp/tests/codebase-index/trace-api-surface.test.ts
+++ b/src/mcp/tests/codebase-index/trace-api-surface.test.ts
@@ -124,7 +124,7 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "OrderService", repo, owner: "vheins", view: "api" },
+			{ name: "OrderService", repo, owner: "vheins", json: true, view: "api" },
 			store,
 			vectors
 		);
@@ -178,7 +178,7 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "PaymentGateway", repo, owner: "vheins", view: "api" },
+			{ name: "PaymentGateway", repo, owner: "vheins", json: true, view: "api" },
 			store,
 			vectors
 		);
@@ -249,7 +249,7 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "OrderService", repo, owner: "vheins", view: "api" },
+			{ name: "OrderService", repo, owner: "vheins", json: true, view: "api" },
 			store,
 			vectors
 		);
@@ -325,7 +325,7 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "Secretive", repo, owner: "vheins", view: "api" },
+			{ name: "Secretive", repo, owner: "vheins", json: true, view: "api" },
 			store,
 			vectors
 		);
@@ -364,7 +364,11 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 		]);
 
 		const run = async () => {
-			const r = await handleCodebaseRead({ name: "WideService", repo, owner: "vheins", view: "api" }, store, vectors);
+			const r = await handleCodebaseRead(
+				{ name: "WideService", repo, owner: "vheins", json: true, view: "api" },
+				store,
+				vectors
+			);
 			return (r.structuredContent as Record<string, unknown>).apiSurface as Record<string, unknown>;
 		};
 		const a = await run();
@@ -405,9 +409,9 @@ describe("TRACE view:'api' — public API surface (issue #86 / TASK-012)", () =>
 			}
 		]);
 
-		const omit = await handleCodebaseRead({ name: "OrderService", repo, owner: "vheins" }, store, vectors);
+		const omit = await handleCodebaseRead({ name: "OrderService", repo, owner: "vheins", json: true }, store, vectors);
 		const def = await handleCodebaseRead(
-			{ name: "OrderService", repo, owner: "vheins", view: "default" },
+			{ name: "OrderService", repo, owner: "vheins", json: true, view: "default" },
 			store,
 			vectors
 		);

--- a/src/mcp/tests/codebase-index/trace-context-packing.test.ts
+++ b/src/mcp/tests/codebase-index/trace-context-packing.test.ts
@@ -434,13 +434,21 @@ describe("handleCodebaseRead TRACE with contextBudget (issue #85)", () => {
 	});
 
 	it("returns an empty contextPack when the flag is omitted (backward compatible)", async () => {
-		const res = await handleCodebaseRead({ name: "alpha", repo, owner: "vheins" }, db, vectors);
+		const res = await handleCodebaseRead({ name: "alpha", repo, owner: "vheins", json: true }, db, vectors);
 		expect(traceData(res).contextPack).toBeUndefined();
 	});
 
 	it("packs within budget and exposes items + tier metadata in the response", async () => {
 		const res = await handleCodebaseRead(
-			{ name: "alpha", repo, owner: "vheins", contextBudget: 10_000, includeRelatedTypes: true, relationDepth: 1 },
+			{
+				name: "alpha",
+				repo,
+				owner: "vheins",
+				json: true,
+				contextBudget: 10_000,
+				includeRelatedTypes: true,
+				relationDepth: 1
+			},
 			db,
 			vectors
 		);
@@ -462,7 +470,7 @@ describe("handleCodebaseRead TRACE with contextBudget (issue #85)", () => {
 
 	it("excludes low-tier candidates when the budget is tight", async () => {
 		const res = await handleCodebaseRead(
-			{ name: "alpha", repo, owner: "vheins", contextBudget: 256 }, // below any single-symbol estimate → only root fits
+			{ name: "alpha", repo, owner: "vheins", json: true, contextBudget: 256 }, // below any single-symbol estimate → only root fits
 			db,
 			vectors
 		);
@@ -477,7 +485,7 @@ describe("handleCodebaseRead TRACE with contextBudget (issue #85)", () => {
 
 	it("rejects an out-of-range contextBudget before any trace runs", async () => {
 		await expect(
-			handleCodebaseRead({ name: "alpha", repo, owner: "vheins", contextBudget: 100 }, db, vectors) // < 256
+			handleCodebaseRead({ name: "alpha", repo, owner: "vheins", json: true, contextBudget: 100 }, db, vectors) // < 256
 		).rejects.toThrow();
 	});
 });

--- a/src/mcp/tests/codebase-index/trace-related-types.test.ts
+++ b/src/mcp/tests/codebase-index/trace-related-types.test.ts
@@ -480,7 +480,11 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 			target_symbol_id: "dto-1"
 		});
 
-		const response = await handleCodebaseRead({ name: "createOrder", repo, owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ name: "createOrder", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = traceData(response);
 
 		expect(data.error).toBeUndefined();
@@ -529,7 +533,7 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 		});
 
 		const response = await handleCodebaseRead(
-			{ name: "createOrder", repo, owner: "vheins", includeRelatedTypes: true },
+			{ name: "createOrder", repo, owner: "vheins", json: true, includeRelatedTypes: true },
 			store,
 			vectors
 		);
@@ -597,7 +601,7 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 		});
 
 		const response = await handleCodebaseRead(
-			{ name: "createOrder", repo, owner: "vheins", includeRelatedTypes: true, relationDepth: 2 },
+			{ name: "createOrder", repo, owner: "vheins", json: true, includeRelatedTypes: true, relationDepth: 2 },
 			store,
 			vectors
 		);
@@ -646,7 +650,7 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 		});
 
 		const response = await handleCodebaseRead(
-			{ name: "TypeA", repo, owner: "vheins", includeRelatedTypes: true, relationDepth: 4 },
+			{ name: "TypeA", repo, owner: "vheins", json: true, includeRelatedTypes: true, relationDepth: 4 },
 			store,
 			vectors
 		);
@@ -679,7 +683,7 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 		});
 
 		const response = await handleCodebaseRead(
-			{ name: "createOrder", repo, owner: "vheins", includeRelatedTypes: true },
+			{ name: "createOrder", repo, owner: "vheins", json: true, includeRelatedTypes: true },
 			store,
 			vectors
 		);
@@ -704,14 +708,14 @@ describe("handleCodebaseRead (trace mode + related types, issue #84)", () => {
 		// surfaces from CodebaseReadSchema.parse before any response is built.
 		await expect(
 			handleCodebaseRead(
-				{ name: "root", repo, owner: "vheins", includeRelatedTypes: true, relationDepth: 5 },
+				{ name: "root", repo, owner: "vheins", json: true, includeRelatedTypes: true, relationDepth: 5 },
 				store,
 				vectors
 			)
 		).rejects.toThrow(/relationDepth/);
 		await expect(
 			handleCodebaseRead(
-				{ name: "root", repo, owner: "vheins", includeRelatedTypes: true, relationDepth: 0 },
+				{ name: "root", repo, owner: "vheins", json: true, includeRelatedTypes: true, relationDepth: 0 },
 				store,
 				vectors
 			)

--- a/src/mcp/tests/codebase-index/trace-symbol.mode.test.ts
+++ b/src/mcp/tests/codebase-index/trace-symbol.mode.test.ts
@@ -63,7 +63,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 			}
 		]);
 
-		const response = await handleCodebaseRead({ name: "authenticate", repo, owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ name: "authenticate", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.error).toBeUndefined();
@@ -106,7 +110,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 			}
 		]);
 
-		const response = await handleCodebaseRead({ name: "authenticate", repo, owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ name: "authenticate", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.error).toBeDefined();
@@ -130,7 +138,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 			}
 		]);
 
-		const response = await handleCodebaseRead({ name: "nonexistent", repo, owner: "vheins" }, store, vectors);
+		const response = await handleCodebaseRead(
+			{ name: "nonexistent", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const data = response.structuredContent as Record<string, unknown>;
 
 		expect(data.error).toContain("nonexistent");
@@ -170,7 +182,7 @@ describe("handleCodebaseRead (trace mode)", () => {
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "authenticate", repo, owner: "vheins", includeReferences: true },
+			{ name: "authenticate", repo, owner: "vheins", json: true, includeReferences: true },
 			store,
 			vectors
 		);
@@ -212,7 +224,7 @@ describe("handleCodebaseRead (trace mode)", () => {
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "authenticate", repo, owner: "vheins", includeReferences: false },
+			{ name: "authenticate", repo, owner: "vheins", json: true, includeReferences: false },
 			store,
 			vectors
 		);
@@ -267,7 +279,7 @@ describe("handleCodebaseRead (trace mode)", () => {
 		]);
 
 		const response = await handleCodebaseRead(
-			{ name: "authenticate", repo, owner: "vheins", includeReferences: true },
+			{ name: "authenticate", repo, owner: "vheins", json: true, includeReferences: true },
 			store,
 			vectors
 		);
@@ -322,7 +334,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 		]);
 
 		// Class trace → children list.
-		const classResponse = await handleCodebaseRead({ name: "UserService", repo, owner: "vheins" }, store, vectors);
+		const classResponse = await handleCodebaseRead(
+			{ name: "UserService", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const classData = classResponse.structuredContent as Record<string, unknown>;
 		expect(classData.error).toBeUndefined();
 		expect(classData.parent).toBeNull();
@@ -330,7 +346,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 		expect(children.map((c) => c.name).sort()).toEqual(["createUser", "deleteUser"]);
 
 		// Method trace → parent descriptor.
-		const methodResponse = await handleCodebaseRead({ name: "createUser", repo, owner: "vheins" }, store, vectors);
+		const methodResponse = await handleCodebaseRead(
+			{ name: "createUser", repo, owner: "vheins", json: true },
+			store,
+			vectors
+		);
 		const methodData = methodResponse.structuredContent as Record<string, unknown>;
 		expect(methodData.error).toBeUndefined();
 		expect(methodData.parent).toEqual({
@@ -371,11 +391,11 @@ describe("handleCodebaseRead (trace mode)", () => {
 				signature: "function nodocFn()"
 			}
 		]);
-		const docced = await handleCodebaseRead({ name: "doccedFn", repo, owner: "vheins" }, store, vectors);
+		const docced = await handleCodebaseRead({ name: "doccedFn", repo, owner: "vheins", json: true }, store, vectors);
 		expect(getPrimaryTextContent(docced)).toMatch(/Doc:/);
 		expect(getPrimaryTextContent(docced)).toMatch(/Does the docced thing/);
 
-		const nodoc = await handleCodebaseRead({ name: "nodocFn", repo, owner: "vheins" }, store, vectors);
+		const nodoc = await handleCodebaseRead({ name: "nodocFn", repo, owner: "vheins", json: true }, store, vectors);
 		expect(getPrimaryTextContent(nodoc)).not.toMatch(/Doc:/);
 	});
 });

--- a/src/mcp/tests/exploration-observation.test.ts
+++ b/src/mcp/tests/exploration-observation.test.ts
@@ -3,8 +3,19 @@ import { createRouter } from "../router";
 import { MigrationManager, SCHEMA_VERSION } from "../storage/migrations";
 import { createTestStore } from "../storage/sqlite";
 import { StubVectorStore } from "../storage/vectors.stub";
+import { fingerprintSourceRange, fingerprintSymbol } from "../utils/source-fingerprint";
 
 describe("exploration observation tools", () => {
+	it("fingerprints only the indexed symbol source range", () => {
+		const before = "const unrelated = 1;\nfunction run() {\n  return 1;\n}\n";
+		const unrelatedEdit = "const unrelated = 2;\nfunction run() {\n  return 1;\n}\n";
+		const symbolEdit = "const unrelated = 1;\nfunction run() {\n  return 2;\n}\n";
+		expect(fingerprintSourceRange(before, 2, 4)).toBe(fingerprintSourceRange(unrelatedEdit, 2, 4));
+		expect(fingerprintSourceRange(before, 2, 4)).not.toBe(fingerprintSourceRange(symbolEdit, 2, 4));
+		const common = { kind: "function", source_fingerprint: fingerprintSourceRange(before, 2, 4) };
+		expect(fingerprintSymbol({ ...common, name: "run" })).not.toBe(fingerprintSymbol({ ...common, name: "stop" }));
+	});
+
 	let db: Awaited<ReturnType<typeof createTestStore>>;
 	let router: ReturnType<typeof createRouter>;
 
@@ -13,8 +24,8 @@ describe("exploration observation tools", () => {
 		router = createRouter(db, new StubVectorStore(db));
 	});
 
-	it("installs the v30 schema, indexes, foreign key, and idempotent migration", () => {
-		expect(SCHEMA_VERSION).toBe(30);
+	it("installs the observation schema, indexes, foreign key, and idempotent migrations", () => {
+		expect(SCHEMA_VERSION).toBe(31);
 		const tables = db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
 			name: string;
 		}>;
@@ -50,10 +61,32 @@ describe("exploration observation tools", () => {
 			])
 		);
 
-		db.db.prepare("DELETE FROM _schema_version WHERE version = 30").run();
+		const evidenceColumns = db.db.prepare("PRAGMA table_info(exploration_evidence)").all() as Array<{ name: string }>;
+		expect(evidenceColumns.map(({ name }) => name)).toEqual(
+			expect.arrayContaining(["file_checksum", "symbol_fingerprint", "indexed_at", "commit_sha"])
+		);
+		const symbolColumns = db.db.prepare("PRAGMA table_info(codebase_symbols)").all() as Array<{ name: string }>;
+		expect(symbolColumns.map(({ name }) => name)).toContain("source_fingerprint");
+		const observationColumns = db.db.prepare("PRAGMA table_info(exploration_observations)").all() as Array<{
+			name: string;
+		}>;
+		expect(observationColumns.map(({ name }) => name)).toEqual(
+			expect.arrayContaining(["stale_reason", "last_verified_at", "superseded_by"])
+		);
+
+		const plan = db.db
+			.prepare(
+				`EXPLAIN QUERY PLAN SELECT DISTINCT o.id
+				 FROM exploration_observations o JOIN exploration_evidence e ON e.observation_id = o.id
+				 WHERE o.repo = ? AND e.file_path IN (?)`
+			)
+			.all("repo", "src/a.ts") as Array<{ detail: string }>;
+		expect(plan.map(({ detail }) => detail).join(" | ")).toContain("idx_exploration_evidence_file");
+
+		for (const version of [30, 31]) db.db.prepare("DELETE FROM _schema_version WHERE version = ?").run(version);
 		expect(() => new MigrationManager(db.db).migrate()).not.toThrow();
-		expect(db.db.prepare("SELECT COUNT(*) AS count FROM _schema_version WHERE version = 30").get()).toEqual({
-			count: 1
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM _schema_version WHERE version IN (30, 31)").get()).toEqual({
+			count: 2
 		});
 	});
 
@@ -174,6 +207,7 @@ describe("exploration observation tools", () => {
 				file_path: "src/checkout.ts",
 				symbol_id: "checkout",
 				min_confidence: 0.9,
+				include_stale: true,
 				json: true
 			}
 		})) as any;
@@ -222,6 +256,125 @@ describe("exploration observation tools", () => {
 		expect(detail.structuredContent.observation.evidence[0].file_path).toBe("src/parser.ts");
 		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_observations").get()).toEqual({ count: 1 });
 		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_evidence").get()).toEqual({ count: 1 });
+	});
+
+	it("tracks fingerprints, excludes stale rows by default, and lazily revalidates", async () => {
+		const file = db.codebaseFiles.upsertFile({
+			repo: "repo",
+			file_path: "src/service.ts",
+			language: "typescript",
+			checksum: "checksum-a",
+			lines: 20,
+			size_bytes: 200
+		});
+		db.codebaseSymbols.bulkUpsertSymbols([
+			{
+				id: "123e4567-e89b-42d3-a456-426614174001",
+				repo: "repo",
+				file_path: "src/service.ts",
+				name: "run",
+				kind: "function",
+				exported: true,
+				start_line: 3,
+				end_line: 8,
+				signature: "run(): void"
+			}
+		]);
+		const created = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "run",
+				fact: "The run function performs the operation.",
+				confidence: 0.95,
+				evidence: [{ file_path: file.file_path, symbol_id: "123e4567-e89b-42d3-a456-426614174001" }],
+				json: true
+			}
+		})) as any;
+		const id = created.structuredContent.results[0].id;
+		const initial = db.explorationObservations.getById("test", "repo", id, true)!;
+		expect(initial.freshness).toBe("valid");
+		expect(initial.evidence![0].file_checksum).toBe("checksum-a");
+		expect(initial.evidence![0].symbol_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+
+		db.codebaseFiles.upsertFile({ ...file, checksum: "checksum-b" });
+		db.explorationObservations.refreshForFiles("repo", [file.file_path]);
+		expect(db.explorationObservations.getById("test", "repo", id)!.freshness).toBe("valid");
+
+		db.codebaseSymbols.deleteSymbolsByFile("repo", file.file_path);
+		db.codebaseSymbols.bulkUpsertSymbols([
+			{
+				id: "123e4567-e89b-42d3-a456-426614174002",
+				repo: "repo",
+				file_path: file.file_path,
+				name: "run",
+				kind: "function",
+				exported: true,
+				start_line: 3,
+				end_line: 9,
+				signature: "run(input: string): void"
+			}
+		]);
+		db.explorationObservations.refreshForFiles("repo", [file.file_path]);
+		expect(db.explorationObservations.getById("test", "repo", id)!.freshness).toBe("stale");
+
+		const hidden = (await router("tools/call", {
+			name: "observation-read",
+			arguments: { owner: "test", repo: "repo", json: true }
+		})) as any;
+		expect(hidden.structuredContent.count).toBe(0);
+		const visible = (await router("tools/call", {
+			name: "observation-read",
+			arguments: { owner: "test", repo: "repo", include_stale: true, json: true }
+		})) as any;
+		expect(visible.structuredContent.count).toBe(1);
+
+		const refreshed = (await router("tools/call", {
+			name: "observation-write",
+			arguments: { owner: "test", repo: "repo", refresh_ids: [id], json: true }
+		})) as any;
+		expect(refreshed.structuredContent.observations[0].freshness).toBe("stale");
+		expect(refreshed.structuredContent.observations[0].stale_reason).toBe("symbol_changed");
+	});
+
+	it("marks deleted sources stale, transfers rename evidence, and supports supersession", async () => {
+		db.codebaseFiles.upsertFile({ repo: "repo", file_path: "src/old.ts", checksum: "a" });
+		const old = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "old",
+				fact: "The old file contains the implementation.",
+				confidence: 0.8,
+				evidence: [{ file_path: "src/old.ts" }],
+				json: true
+			}
+		})) as any;
+		const oldId = old.structuredContent.results[0].id;
+		db.codebaseFiles.transferFile("repo", "src/old.ts", "src/new.ts");
+		db.explorationObservations.transferEvidencePath("repo", "src/old.ts", "src/new.ts");
+		expect(db.explorationObservations.getById("test", "repo", oldId, true)!.evidence![0].file_path).toBe("src/new.ts");
+
+		const replacement = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "new",
+				fact: "The renamed file contains the implementation.",
+				confidence: 0.95,
+				supersedes_id: oldId,
+				evidence: [{ file_path: "src/new.ts" }],
+				json: true
+			}
+		})) as any;
+		const replacementId = replacement.structuredContent.results[0].id;
+		expect(db.explorationObservations.getById("test", "repo", oldId)!.superseded_by).toBe(replacementId);
+
+		db.explorationObservations.markFilesStale("repo", ["src/new.ts"], "file_deleted");
+		expect(db.explorationObservations.getById("test", "repo", replacementId)!.stale_reason).toBe("file_deleted");
 	});
 
 	it("keeps compact reads evidence-free and hydrates evidence explicitly", async () => {

--- a/src/mcp/tests/exploration-observation.test.ts
+++ b/src/mcp/tests/exploration-observation.test.ts
@@ -25,7 +25,7 @@ describe("exploration observation tools", () => {
 	});
 
 	it("installs the observation schema, indexes, foreign key, and idempotent migrations", () => {
-		expect(SCHEMA_VERSION).toBe(31);
+		expect(SCHEMA_VERSION).toBe(32);
 		const tables = db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
 			name: string;
 		}>;

--- a/src/mcp/tests/exploration-observation.test.ts
+++ b/src/mcp/tests/exploration-observation.test.ts
@@ -25,7 +25,7 @@ describe("exploration observation tools", () => {
 	});
 
 	it("installs the observation schema, indexes, foreign key, and idempotent migrations", () => {
-		expect(SCHEMA_VERSION).toBe(32);
+		expect(SCHEMA_VERSION).toBe(33);
 		const tables = db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
 			name: string;
 		}>;

--- a/src/mcp/tests/exploration-observation.test.ts
+++ b/src/mcp/tests/exploration-observation.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createRouter } from "../router";
+import { MigrationManager, SCHEMA_VERSION } from "../storage/migrations";
+import { createTestStore } from "../storage/sqlite";
+import { StubVectorStore } from "../storage/vectors.stub";
+
+describe("exploration observation tools", () => {
+	let db: Awaited<ReturnType<typeof createTestStore>>;
+	let router: ReturnType<typeof createRouter>;
+
+	beforeEach(async () => {
+		db = await createTestStore();
+		router = createRouter(db, new StubVectorStore(db));
+	});
+
+	it("installs the v30 schema, indexes, foreign key, and idempotent migration", () => {
+		expect(SCHEMA_VERSION).toBe(30);
+		const tables = db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
+			name: string;
+		}>;
+		expect(tables.map(({ name }) => name)).toEqual(
+			expect.arrayContaining(["exploration_observations", "exploration_evidence"])
+		);
+		const indexes = db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as Array<{
+			name: string;
+		}>;
+		expect(indexes.map(({ name }) => name)).toEqual(
+			expect.arrayContaining([
+				"idx_exploration_obs_scope_subject",
+				"idx_exploration_obs_scope_task",
+				"idx_exploration_obs_scope_confidence",
+				"idx_exploration_evidence_file",
+				"idx_exploration_evidence_symbol"
+			])
+		);
+		const foreignKeys = db.db.prepare("PRAGMA foreign_key_list(exploration_evidence)").all() as Array<{
+			table: string;
+			from: string;
+			to: string;
+			on_delete: string;
+		}>;
+		expect(foreignKeys).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					table: "exploration_observations",
+					from: "observation_id",
+					to: "id",
+					on_delete: "CASCADE"
+				})
+			])
+		);
+
+		db.db.prepare("DELETE FROM _schema_version WHERE version = 30").run();
+		expect(() => new MigrationManager(db.db).migrate()).not.toThrow();
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM _schema_version WHERE version = 30").get()).toEqual({
+			count: 1
+		});
+	});
+
+	it("publishes 20 observations atomically and deduplicates retries", async () => {
+		const observations = Array.from({ length: 20 }, (_, index) => ({
+			subject: `symbol-${index}`,
+			fact: `Symbol ${index} validates input before writing.`,
+			confidence: 0.9,
+			agent: "explorer",
+			task_id: "task-1",
+			evidence: [{ file_path: `src/file-${index}.ts`, symbol_id: `symbol-${index}`, start_line: 10, end_line: 14 }]
+		}));
+
+		const first = (await router("tools/call", {
+			name: "observation-write",
+			arguments: { owner: "test", repo: "repo", observations, json: true }
+		})) as any;
+		expect(first.isError).toBe(false);
+		expect(first.structuredContent.created).toBe(20);
+		expect(first.structuredContent.deduplicated).toBe(0);
+
+		const retry = (await router("tools/call", {
+			name: "observation-write",
+			arguments: { owner: "test", repo: "repo", observations, json: true }
+		})) as any;
+		expect(retry.structuredContent.created).toBe(0);
+		expect(retry.structuredContent.deduplicated).toBe(20);
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_observations").get()).toEqual({ count: 20 });
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_evidence").get()).toEqual({ count: 20 });
+	});
+
+	it("keeps idempotent retries byte-stable", async () => {
+		const args = {
+			owner: "test",
+			repo: "repo",
+			subject: "cache",
+			fact: "Cache keys include repository scope.",
+			confidence: 0.88,
+			evidence: [{ file_path: "src/cache.ts", symbol_id: "cacheKey", start_line: 3, end_line: 6 }],
+			json: true
+		};
+		const first = (await router("tools/call", { name: "observation-write", arguments: args })) as any;
+		const id = first.structuredContent.results[0].id;
+		const before = db.db.prepare("SELECT * FROM exploration_observations WHERE id = ?").get(id);
+		const evidenceBefore = db.db.prepare("SELECT * FROM exploration_evidence WHERE observation_id = ?").all(id);
+
+		const retry = (await router("tools/call", { name: "observation-write", arguments: args })) as any;
+		expect(retry.structuredContent.deduplicated).toBe(1);
+		expect(db.db.prepare("SELECT * FROM exploration_observations WHERE id = ?").get(id)).toEqual(before);
+		expect(db.db.prepare("SELECT * FROM exploration_evidence WHERE observation_id = ?").all(id)).toEqual(
+			evidenceBefore
+		);
+	});
+
+	it("rejects an end line without a start line", async () => {
+		const response = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "invalid-range",
+				fact: "An end-only evidence range is ambiguous.",
+				confidence: 0.8,
+				evidence: [{ file_path: "src/a.ts", end_line: 10 }]
+			}
+		})) as any;
+		expect(response.isError).toBe(true);
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_observations").get()).toEqual({ count: 0 });
+	});
+
+	it("rolls back the entire bulk when one observation is malformed", async () => {
+		const response = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				observations: [
+					{
+						subject: "valid",
+						fact: "A valid high-signal fact.",
+						confidence: 0.8,
+						evidence: [{ file_path: "src/a.ts" }]
+					},
+					{ subject: "invalid", fact: "Missing evidence.", confidence: 0.8, evidence: [] }
+				],
+				json: true
+			}
+		})) as any;
+		expect(response.isError).toBe(true);
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_observations").get()).toEqual({ count: 0 });
+	});
+
+	it("isolates owner/repo and queries by task, subject, file, symbol, and confidence", async () => {
+		for (const owner of ["alpha", "beta"]) {
+			await router("tools/call", {
+				name: "observation-write",
+				arguments: {
+					owner,
+					repo: "repo",
+					subject: "checkout",
+					fact: `${owner} checkout validates inventory.`,
+					confidence: owner === "alpha" ? 0.95 : 0.5,
+					task_id: "task-7",
+					agent: "explorer",
+					evidence: [{ file_path: "src/checkout.ts", symbol_id: "checkout", start_line: 4, end_line: 9 }],
+					json: true
+				}
+			});
+		}
+
+		const response = (await router("tools/call", {
+			name: "observation-read",
+			arguments: {
+				owner: "alpha",
+				repo: "repo",
+				subject: "checkout",
+				task_id: "task-7",
+				file_path: "src/checkout.ts",
+				symbol_id: "checkout",
+				min_confidence: 0.9,
+				json: true
+			}
+		})) as any;
+		expect(response.structuredContent.count).toBe(1);
+		expect(response.structuredContent.observations.rows[0]).toContain("alpha checkout validates inventory.");
+	});
+
+	it("updates an observation in scope while preserving its identity and replacing evidence", async () => {
+		const created = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "parser",
+				fact: "Parser accepts the legacy shape.",
+				confidence: 0.7,
+				evidence: [{ file_path: "src/legacy.ts", start_line: 2, end_line: 4 }],
+				json: true
+			}
+		})) as any;
+		const id = created.structuredContent.results[0].id;
+
+		const updated = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				id,
+				subject: "parser",
+				fact: "Parser accepts only the canonical shape.",
+				confidence: 0.98,
+				evidence: [{ file_path: "src/parser.ts", symbol_id: "parse", start_line: 8, end_line: 12 }],
+				json: true
+			}
+		})) as any;
+		expect(updated.isError).toBe(false);
+		expect(updated.structuredContent.mode).toBe("update");
+		expect(updated.structuredContent.results[0].id).toBe(id);
+
+		const detail = (await router("tools/call", {
+			name: "observation-read",
+			arguments: { owner: "test", repo: "repo", id, hydrate_evidence: true, json: true }
+		})) as any;
+		expect(detail.structuredContent.observation.fact).toBe("Parser accepts only the canonical shape.");
+		expect(detail.structuredContent.observation.evidence).toHaveLength(1);
+		expect(detail.structuredContent.observation.evidence[0].file_path).toBe("src/parser.ts");
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_observations").get()).toEqual({ count: 1 });
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM exploration_evidence").get()).toEqual({ count: 1 });
+	});
+
+	it("keeps compact reads evidence-free and hydrates evidence explicitly", async () => {
+		const created = (await router("tools/call", {
+			name: "observation-write",
+			arguments: {
+				owner: "test",
+				repo: "repo",
+				subject: "writer",
+				fact: "Writer commits all evidence atomically.",
+				confidence: 1,
+				evidence: [{ file_path: "src/writer.ts", start_line: 1, end_line: 20 }],
+				json: true
+			}
+		})) as any;
+		const id = created.structuredContent.results[0].id;
+
+		const compact = (await router("tools/call", {
+			name: "observation-read",
+			arguments: { owner: "test", repo: "repo", json: true }
+		})) as any;
+		expect(compact.structuredContent.observations.columns).not.toContain("evidence");
+
+		const detail = (await router("tools/call", {
+			name: "observation-read",
+			arguments: { owner: "test", repo: "repo", id, hydrate_evidence: true, json: true }
+		})) as any;
+		expect(detail.structuredContent.mode).toBe("detail");
+		expect(detail.structuredContent.observation.evidence).toHaveLength(1);
+		expect(detail.structuredContent.observation.evidence[0].file_path).toBe("src/writer.ts");
+	});
+});

--- a/src/mcp/tests/handoff.tools.test.ts
+++ b/src/mcp/tests/handoff.tools.test.ts
@@ -67,6 +67,7 @@ describe("MCP handoff-write, handoff-read, and claim-manage tools", () => {
 		});
 
 		expect(listRes.structuredContent.schema).toBe("handoff-read");
+		expect(listRes.structuredContent.mode).toBe("list");
 		expect(listRes.structuredContent.count).toBe(1);
 		expect(listRes.structuredContent.handoffs.rows[0][1]).toBe("agent-a");
 		expect(listRes.structuredContent.handoffs.rows[0][4]).toBe("HANDOFF-101");

--- a/src/mcp/tests/kg-bloat-retention.test.ts
+++ b/src/mcp/tests/kg-bloat-retention.test.ts
@@ -5,7 +5,7 @@
  *   F0  — bounded `co_mentioned` clique in `saveExtractions`
  *   F1  — `deleteStaleObservations` (parent-aware) + `deleteUnreachableRelations`
  *   F2  — `getRelationsFor` bounded UNION with confidence ranking
- *   F6  — `getEntitiesFor` is no longer repo-filtered (global entities PK)
+ *   F6  — `getEntitiesFor` resolves repository-scoped entity identities
  *   F8  — markdown-heading / ordinal entity names rejected
  *   F12 — relation writers emit contract-format observation text
  *   F13 — bounded task/standard relation cross-products
@@ -209,7 +209,7 @@ describe("KG audit F2 — getRelationsFor is bounded and confidence-ranked", () 
 // F6 — entities lookup must not be repo-filtered
 // ---------------------------------------------------------------------------
 
-describe("KG audit F6 — getEntitiesFor resolves entities owned by another repo", () => {
+describe("KG repository-scoped entity identity", () => {
 	let db: SQLiteStore;
 
 	beforeEach(async () => {
@@ -217,24 +217,23 @@ describe("KG audit F6 — getEntitiesFor resolves entities owned by another repo
 	});
 	afterEach(() => db.close());
 
-	it("finds an entity whose row was claimed first by a different repo", () => {
-		// repo-a wins the global PK for the common noun...
+	it("returns the repository-local row when names collide", () => {
 		seedEntity(db, "priority", "repo-a");
-		// ...and repo-b's INSERT OR IGNORE is silently dropped.
 		seedEntity(db, "priority", "repo-b");
 
-		const rows = db.knowledgeGraph.getEntitiesFor(["priority"]);
+		const rows = db.knowledgeGraph.getEntitiesFor(["priority"], "repo-b");
 
 		expect(rows).toHaveLength(1);
 		expect(rows[0].name).toBe("priority");
 	});
 
-	it("no longer drops entities while their edges are still shipped", () => {
+	it("returns every endpoint from the relation's repository", () => {
 		seedEntity(db, "priority", "repo-a");
+		seedEntity(db, "priority", "repo-b");
 		seedEntity(db, "section", "repo-b");
 		seedRelation(db, "priority", "section", { repo: "repo-b" });
 
-		const entities = db.knowledgeGraph.getEntitiesFor(["priority", "section"]);
+		const entities = db.knowledgeGraph.getEntitiesFor(["priority", "section"], "repo-b");
 		const relations = db.knowledgeGraph.getRelationsFor(["priority", "section"], "repo-b", 0);
 
 		// Every endpoint of every shipped edge is present in the entity payload.
@@ -246,7 +245,7 @@ describe("KG audit F6 — getEntitiesFor resolves entities owned by another repo
 	});
 
 	it("returns [] for an empty name set", () => {
-		expect(db.knowledgeGraph.getEntitiesFor([])).toEqual([]);
+		expect(db.knowledgeGraph.getEntitiesFor([], "repo-a")).toEqual([]);
 	});
 });
 
@@ -366,15 +365,15 @@ describe("KG audit F1 — deleteUnreachableRelations", () => {
 		expect(survivor.from_entity).toBe("observedA");
 	});
 
-	it("keeps an edge whose endpoint is observed in ANOTHER repo (global entity names)", () => {
+	it("prunes an edge when its endpoint is observed only in another repository", () => {
 		seedEntity(db, "sharedA", "repo-a", OLD);
+		seedEntity(db, "sharedA", "repo-b", OLD);
 		seedEntity(db, "sharedB", "repo-b", OLD);
-		// Observation lives in repo-a; the edge lives in repo-b.
 		seedObservation(db, "sharedA", observationText("memory", "Cross Memory"), "repo-a", OLD);
 		seedRelation(db, "sharedA", "sharedB", { repo: "repo-b", created_at: OLD });
 
-		expect(db.knowledgeGraph.deleteUnreachableRelations(NOW, 1000, 100)).toBe(0);
-		expect(countRelations(db)).toBe(1);
+		expect(db.knowledgeGraph.deleteUnreachableRelations(NOW, 1000, 100)).toBe(1);
+		expect(countRelations(db)).toBe(0);
 	});
 
 	it("respects the age guard — fresh edges are never swept", () => {
@@ -489,9 +488,11 @@ describe("KG audit F12/F13 — saveTaskRelations", () => {
 
 		await saveTaskRelations("Alice deployed Redis", "Child Task", OWNER, REPO, db, { parentId: parent.id });
 
-		const texts = (db.db.prepare("SELECT DISTINCT observation FROM observations").all() as Array<{
-			observation: string;
-		}>).map((r) => r.observation);
+		const texts = (
+			db.db.prepare("SELECT DISTINCT observation FROM observations").all() as Array<{
+				observation: string;
+			}>
+		).map((r) => r.observation);
 
 		expect(texts.length).toBeGreaterThan(0);
 		// Every row is matchable by deleteObservationsAndOrphans.

--- a/src/mcp/tests/kg-entity-names.test.ts
+++ b/src/mcp/tests/kg-entity-names.test.ts
@@ -94,10 +94,9 @@ describe("getEntityNamesByText — cap truncation", () => {
 
 describe("getEntityNamesByText — repo scoping", () => {
 	it("returns only names from the requested repo", () => {
-		// entities.name is the GLOBAL primary key (v01), so identical NAMES
-		// cannot exist across repos — but identical TOKENS can. repoB shares
-		// the "payment" token with repoA to prove the repo filter (both in
-		// the FTS WHERE clause and the INSTR fallback) keeps rows scoped.
+		// Identical entity names can exist across repositories since v33. This
+		// uses distinct names sharing a token to prove both FTS and fallback
+		// queries remain repository-scoped.
 		createEntity("Payment Service", "repoA");
 		createEntity("Payment Gateway", "repoA");
 		createEntity("Payment Ledger", "repoB"); // same token, different name

--- a/src/mcp/tests/kg-entity-observation-atomicity.test.ts
+++ b/src/mcp/tests/kg-entity-observation-atomicity.test.ts
@@ -64,7 +64,7 @@ describe("KG Archivist — entity+observation pair atomicity (TASK-073)", () => 
 		// insert. Without the BEGIN IMMEDIATE wrapper the upsert would have
 		// autocommitted and left an orphaned entity (referenced by neither an
 		// observation nor a relation) — the exact regression this guards.
-		expect(db.knowledgeGraph.getEntityByName("A")).toBeUndefined();
+		expect(db.knowledgeGraph.getEntityByName("A", REPO)).toBeUndefined();
 	});
 
 	it("an orphan sweep from a second connection cannot delete an endpoint between its upsert and observation insert", async () => {
@@ -122,7 +122,7 @@ describe("KG Archivist — entity+observation pair atomicity (TASK-073)", () => 
 			expect(fkWarns).toHaveLength(0);
 
 			// Both the entity and its observation were persisted atomically.
-			expect(fileDb.knowledgeGraph.getEntityByName("Alice")).toBeDefined();
+			expect(fileDb.knowledgeGraph.getEntityByName("Alice", REPO)).toBeDefined();
 			const observations = fileDb.db
 				.prepare("SELECT entity_name FROM observations WHERE entity_name = 'Alice'")
 				.all() as Array<{ entity_name: string }>;
@@ -203,7 +203,7 @@ describe("KG Archivist — entity+observation pair atomicity (TASK-073)", () => 
 		);
 
 		// The decision entity is upserted by ensureRelation with type "decision".
-		const decision = db.knowledgeGraph.getEntityByName("ADR-006");
+		const decision = db.knowledgeGraph.getEntityByName("ADR-006", REPO);
 		expect(decision).toBeDefined();
 		expect(decision?.type).toBe("decision");
 
@@ -214,7 +214,7 @@ describe("KG Archivist — entity+observation pair atomicity (TASK-073)", () => 
 		expect(rels.length).toBeGreaterThan(0);
 		for (const rel of rels) {
 			expect(rel.to_entity).toBe("ADR-006");
-			expect(db.knowledgeGraph.getEntityByName(rel.from_entity)).toBeDefined();
+			expect(db.knowledgeGraph.getEntityByName(rel.from_entity, REPO)).toBeDefined();
 		}
 	});
 
@@ -226,8 +226,8 @@ describe("KG Archivist — entity+observation pair atomicity (TASK-073)", () => 
 			.all() as Array<{ from_entity: string; to_entity: string }>;
 		expect(rels.length).toBeGreaterThan(0);
 		for (const rel of rels) {
-			expect(db.knowledgeGraph.getEntityByName(rel.from_entity)).toBeDefined();
-			expect(db.knowledgeGraph.getEntityByName(rel.to_entity)).toBeDefined();
+			expect(db.knowledgeGraph.getEntityByName(rel.from_entity, REPO)).toBeDefined();
+			expect(db.knowledgeGraph.getEntityByName(rel.to_entity, REPO)).toBeDefined();
 		}
 	});
 });

--- a/src/mcp/tests/kg-graph-edges.test.ts
+++ b/src/mcp/tests/kg-graph-edges.test.ts
@@ -271,7 +271,7 @@ describe("KnowledgeGraphEntity — subset-bounded graph edges (TASK-268)", () =>
 		expect(degreeRow.degree).toBe(4);
 
 		// Deleting the relation decrements back to 3.
-		db.knowledgeGraph.deleteRelation("B", "A", "backlink");
+		db.knowledgeGraph.deleteRelation("B", "A", "backlink", REPO);
 		const after = db.db.prepare("SELECT degree FROM kg_degrees WHERE repo = ? AND node = ?").get(REPO, "A") as {
 			degree: number;
 		};

--- a/src/mcp/tests/kg-json-gate.test.ts
+++ b/src/mcp/tests/kg-json-gate.test.ts
@@ -161,6 +161,9 @@ describe("KG audit F3 — the KG lookup is skipped when json is false", () => {
 
 		const json = await handleMemoryRead({ owner: OWNER, repo: REPO, query: "AuthModule", json: true }, db, vectors);
 		expect(spy).toHaveBeenCalled();
+		expect(json.content?.[0]).toMatchObject({ type: "text" });
+		expect((json.content?.[0] as { text: string }).text.length).toBeGreaterThan(0);
+		expect(json.structuredContent).toMatchObject({ schema: "memory-read", mode: "search" });
 		expect((json.structuredContent as Record<string, unknown>).kg).toBeDefined();
 	});
 
@@ -184,8 +187,9 @@ describe("KG audit F3 — the KG lookup is skipped when json is false", () => {
 		await handleMemoryRead({ owner: OWNER, repo: REPO, id: memory.id }, db, vectors);
 		expect(spy).not.toHaveBeenCalled();
 
-		await handleMemoryRead({ owner: OWNER, repo: REPO, id: memory.id, json: true }, db, vectors);
+		const json = await handleMemoryRead({ owner: OWNER, repo: REPO, id: memory.id, json: true }, db, vectors);
 		expect(spy).toHaveBeenCalled();
+		expect(json.structuredContent).toMatchObject({ schema: "memory-read", mode: "detail", memory: { id: memory.id } });
 	});
 
 	it("task-read LIST: resolver untouched in text mode, called in json mode", async () => {
@@ -195,8 +199,11 @@ describe("KG audit F3 — the KG lookup is skipped when json is false", () => {
 		await handleTaskRead({ owner: OWNER, repo: REPO }, db, vectors);
 		expect(spy).not.toHaveBeenCalled();
 
-		await handleTaskRead({ owner: OWNER, repo: REPO, json: true }, db, vectors);
+		const json = await handleTaskRead({ owner: OWNER, repo: REPO, json: true }, db, vectors);
 		expect(spy).toHaveBeenCalled();
+		expect(json.content?.[0]).toMatchObject({ type: "text" });
+		expect((json.content?.[0] as { text: string }).text.length).toBeGreaterThan(0);
+		expect(json.structuredContent).toMatchObject({ schema: "task-read/list", mode: "list" });
 	});
 
 	it("task-read DETAIL: resolver untouched in text mode", async () => {
@@ -204,9 +211,14 @@ describe("KG audit F3 — the KG lookup is skipped when json is false", () => {
 		db.tasks.insertTask(task);
 		const spy = vi.spyOn(db.knowledgeGraph, "getEntityNamesByText");
 
-		await handleTaskRead({ owner: OWNER, repo: REPO, id: task.id }, db, vectors);
-
+		const text = await handleTaskRead({ owner: OWNER, repo: REPO, id: task.id }, db, vectors);
 		expect(spy).not.toHaveBeenCalled();
+		expect(text.structuredContent).toBeUndefined();
+
+		const json = await handleTaskRead({ owner: OWNER, repo: REPO, id: task.id, json: true }, db, vectors);
+		expect(json.content?.[0]).toMatchObject({ type: "text" });
+		expect((json.content?.[0] as { text: string }).text.length).toBeGreaterThan(0);
+		expect(json.structuredContent).toMatchObject({ schema: "task-read/detail", mode: "detail", id: task.id });
 	});
 });
 
@@ -229,7 +241,9 @@ describe("KG audit F4 — standard-read honours the json flag in every mode", ()
 		expect(text.structuredContent).toBeUndefined();
 
 		const json = await handleStandardRead({ owner: OWNER, repo: REPO, json: true }, db, vectors);
-		expect(json.structuredContent).toBeDefined();
+		expect(json.content?.[0]).toMatchObject({ type: "text" });
+		expect((json.content?.[0] as { text: string }).text.length).toBeGreaterThan(0);
+		expect(json.structuredContent).toMatchObject({ schema: "standard-read", mode: "list" });
 	});
 
 	it("SEARCH mode: no structuredContent without json, present with json", async () => {
@@ -237,7 +251,7 @@ describe("KG audit F4 — standard-read honours the json flag in every mode", ()
 		expect(text.structuredContent).toBeUndefined();
 
 		const json = await handleStandardRead({ owner: OWNER, repo: REPO, query: "AuthModule", json: true }, db, vectors);
-		expect(json.structuredContent).toBeDefined();
+		expect(json.structuredContent).toMatchObject({ schema: "standard-read", mode: "search" });
 	});
 
 	it("LIST mode: the KG resolver is not called in text mode", async () => {

--- a/src/mcp/tests/kg-relation-confidence.test.ts
+++ b/src/mcp/tests/kg-relation-confidence.test.ts
@@ -74,7 +74,7 @@ describe("KnowledgeGraphEntity — relation confidence (TASK-325)", () => {
 			created_at: now
 		});
 
-		const rows = db.knowledgeGraph.getRelationsByName("A");
+		const rows = db.knowledgeGraph.getRelationsByName("A", REPO);
 		expect(rows).toHaveLength(2);
 		const aToB = rows.find((r) => r.from_entity === "A" && r.to_entity === "B");
 		expect(aToB?.confidence).toBe(0.8);
@@ -198,7 +198,8 @@ describe("KnowledgeGraphEntity — relation confidence (TASK-325)", () => {
 		await saveExtractions("Alice and Bob worked on the project", "Memory 1", "test", REPO, db);
 
 		const row = db.db.prepare("SELECT confidence FROM relations WHERE relation_type = 'co_mentioned'").get() as
-			{ confidence: number } | undefined;
+			| { confidence: number }
+			| undefined;
 		expect(row).toBeDefined();
 		expect(row!.confidence).toBe(0.55);
 	});
@@ -249,7 +250,8 @@ describe("KnowledgeGraphEntity — relation confidence (TASK-325)", () => {
 		// Deterministic endpoints (same corpus as the FK-integrity describe):
 		// child "Payroll Module implementation" → parent "Icons theme".
 		const row = db.db.prepare("SELECT confidence FROM relations WHERE relation_type = 'depends_on'").get() as
-			{ confidence: number } | undefined;
+			| { confidence: number }
+			| undefined;
 		expect(row).toBeDefined();
 		expect(row!.confidence).toBe(0.8);
 	});
@@ -272,7 +274,8 @@ describe("KnowledgeGraphEntity — relation confidence (TASK-325)", () => {
 		await saveCodebaseRelations({ filePath, owner: "test", repo: REPO }, db);
 
 		const row = db.db.prepare("SELECT confidence FROM relations WHERE relation_type = 'call'").get() as
-			{ confidence: number } | undefined;
+			| { confidence: number }
+			| undefined;
 		expect(row).toBeDefined();
 		expect(row!.confidence).toBe(0.9);
 	});

--- a/src/mcp/tests/kg-relations-atomicity.test.ts
+++ b/src/mcp/tests/kg-relations-atomicity.test.ts
@@ -92,14 +92,14 @@ describe("KG Archivist — saveTaskRelations FK integrity (TASK-065)", () => {
 
 		// First pass: ensureRelation upserts BOTH endpoints and inserts the edge.
 		await saveTaskRelations(CHILD_DESCRIPTION, CHILD_TITLE, "test", REPO, db, { parentId: parent.id });
-		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY)).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY, REPO)).toBeDefined();
 		expect(getDependsOn(CHILD_ENTITY, PARENT_ENTITY)).toBeDefined();
 
 		// Simulate the orphan sweep of the parent document's entities
 		// (deleteEntity cascades the depends_on edge away — the exact
 		// post-sweep state that used to flood FK warnings on reprocess).
-		db.knowledgeGraph.deleteEntity(PARENT_ENTITY);
-		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY)).toBeUndefined();
+		db.knowledgeGraph.deleteEntity(PARENT_ENTITY, REPO);
+		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY, REPO)).toBeUndefined();
 		expect(getDependsOn(CHILD_ENTITY, PARENT_ENTITY)).toBeUndefined();
 
 		// Reprocessing the child after the sweep: ensureRelation must upsert
@@ -107,7 +107,7 @@ describe("KG Archivist — saveTaskRelations FK integrity (TASK-065)", () => {
 		const warnSpy = vi.spyOn(logger, "warn");
 		await saveTaskRelations(CHILD_DESCRIPTION, CHILD_TITLE, "test", REPO, db, { parentId: parent.id });
 
-		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY)).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY, REPO)).toBeDefined();
 		expect(getDependsOn(CHILD_ENTITY, PARENT_ENTITY)).toBeDefined();
 		const fkWarns = warnSpy.mock.calls.filter((call) => String(call[0]).includes("Failed to save depends_on relation"));
 		expect(fkWarns).toHaveLength(0);
@@ -137,7 +137,7 @@ describe("KG Archivist — saveTaskRelations FK integrity (TASK-065)", () => {
 			.prepare("SELECT COUNT(*) as cnt FROM relations WHERE relation_type = 'depends_on'")
 			.get() as { cnt: number };
 		expect(dependsOn.cnt).toBe(0);
-		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY)).toBeUndefined();
+		expect(db.knowledgeGraph.getEntityByName(PARENT_ENTITY, REPO)).toBeUndefined();
 	});
 });
 
@@ -195,8 +195,8 @@ describe("KnowledgeGraphEntity — ensureRelation atomicity (TASK-072)", () => {
 
 		// Rollback proof: neither endpoint survives the failed relation insert.
 		// Without the BEGIN IMMEDIATE wrapper these would have autocommitted.
-		expect(db.knowledgeGraph.getEntityByName("A")).toBeUndefined();
-		expect(db.knowledgeGraph.getEntityByName("B")).toBeUndefined();
+		expect(db.knowledgeGraph.getEntityByName("A", REPO)).toBeUndefined();
+		expect(db.knowledgeGraph.getEntityByName("B", REPO)).toBeUndefined();
 	});
 
 	it("nested inside an outer transaction, ensureRelation commits atomically via savepoints", () => {
@@ -231,10 +231,10 @@ describe("KnowledgeGraphEntity — ensureRelation atomicity (TASK-072)", () => {
 			.immediate();
 
 		// Both endpoint pairs and both edges committed atomically.
-		expect(db.knowledgeGraph.getEntityByName("A")).toBeDefined();
-		expect(db.knowledgeGraph.getEntityByName("B")).toBeDefined();
-		expect(db.knowledgeGraph.getEntityByName("C")).toBeDefined();
-		expect(db.knowledgeGraph.getEntityByName("D")).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName("A", REPO)).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName("B", REPO)).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName("C", REPO)).toBeDefined();
+		expect(db.knowledgeGraph.getEntityByName("D", REPO)).toBeDefined();
 		expect(db.knowledgeGraph.listRelations(REPO)).toHaveLength(2);
 	});
 });

--- a/src/mcp/tests/mcp-error.test.ts
+++ b/src/mcp/tests/mcp-error.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { formatZodError, parseArgs, toErrorResponse } from "../utils/mcp-error";
+import {
+	createMcpErrorResponse,
+	formatZodError,
+	parseArgs,
+	ToolError,
+	toErrorResponse
+} from "../utils/mcp-error";
 
 const ScopeSchema = z.object({
 	owner: z.string().min(1, "owner is required — provide it explicitly or configure MCP workspace roots"),
@@ -9,16 +15,60 @@ const ScopeSchema = z.object({
 const SimpleSchema = z.object({ name: z.string().min(3) });
 
 describe("mcp-error — canonical error envelope (OPT-CODE-01)", () => {
-	it("produces the Error: <message> envelope for a plain Error", () => {
-		const res = toErrorResponse(new Error("Task not found: abc"));
+	it("creates a machine-readable error envelope", () => {
+		const res = createMcpErrorResponse({
+			code: "PATH_NOT_FOUND",
+			message: "Repository path not found",
+			retryable: false,
+			details: { field: "repoPath" }
+		});
+
 		expect(res.isError).toBe(true);
-		expect(res.content?.[0]).toEqual({ type: "text", text: "Error: Task not found: abc" });
+		expect(res.content).toEqual([{ type: "text", text: "Repository path not found" }]);
+		expect(res.structuredContent).toEqual({
+			field: "repoPath",
+			schema: "tool-error",
+			code: "PATH_NOT_FOUND",
+			message: "Repository path not found",
+			retryable: false,
+			error: "Repository path not found",
+			details: { field: "repoPath" }
+		});
 	});
 
-	it("produces an isError envelope for a non-Error value", () => {
-		const res = toErrorResponse("boom");
+	it("preserves typed expected failures", () => {
+		const res = toErrorResponse(
+			new ToolError("TASK_NOT_FOUND", "Task not found: abc", { retryable: false, details: { task: "abc" } })
+		);
 		expect(res.isError).toBe(true);
-		expect(res.content?.[0]).toMatchObject({ type: "text", text: "Error: boom" });
+		expect(res.content?.[0]).toEqual({ type: "text", text: "Task not found: abc" });
+		expect(res.structuredContent).toMatchObject({
+			schema: "tool-error",
+			code: "TASK_NOT_FOUND",
+			retryable: false,
+			details: { task: "abc" }
+		});
+	});
+
+	it("sanitizes unknown Error messages", () => {
+		const res = toErrorResponse(new Error("SQLITE failure at /private/secret.db"));
+		expect(res.isError).toBe(true);
+		expect(res.content?.[0]).toEqual({ type: "text", text: "Internal tool error" });
+		expect(res.structuredContent).toEqual({
+			schema: "tool-error",
+			code: "INTERNAL_ERROR",
+			message: "Internal tool error",
+			retryable: false,
+			error: "Internal tool error"
+		});
+		expect(JSON.stringify(res)).not.toContain("secret.db");
+	});
+
+	it("sanitizes non-Error values", () => {
+		const res = toErrorResponse("boom /private/path");
+		expect(res.isError).toBe(true);
+		expect(res.structuredContent).toMatchObject({ code: "INTERNAL_ERROR" });
+		expect(JSON.stringify(res)).not.toContain("private/path");
 	});
 
 	it("formats Zod failures with the friendly Missing required fields text for owner/repo", () => {
@@ -39,7 +89,7 @@ describe("mcp-error — canonical error envelope (OPT-CODE-01)", () => {
 		}
 	});
 
-	it("toErrorResponse wraps a ZodError with the friendly message", () => {
+	it("toErrorResponse wraps a ZodError with the validation code", () => {
 		const result = ScopeSchema.safeParse({});
 		if (!result.success) {
 			const res = toErrorResponse(result.error);
@@ -47,6 +97,11 @@ describe("mcp-error — canonical error envelope (OPT-CODE-01)", () => {
 			expect(res.content?.[0]).toMatchObject({
 				type: "text",
 				text: expect.stringContaining("Missing required fields") as unknown
+			});
+			expect(res.structuredContent).toMatchObject({
+				schema: "tool-error",
+				code: "VALIDATION_ERROR",
+				retryable: false
 			});
 		}
 	});

--- a/src/mcp/tests/memory.delete.test.ts
+++ b/src/mcp/tests/memory.delete.test.ts
@@ -224,6 +224,8 @@ describe("MCP Local Memory - memory-delete (Single & Bulk)", () => {
 			}
 		});
 
+		expect(delRes.isError).toBe(true);
+		expect(delRes.structuredContent).toMatchObject({ schema: "tool-error", code: "PARTIAL_FAILURE" });
 		expect(delRes.structuredContent.success).toBe(true);
 		expect(delRes.structuredContent.deletedCount).toBe(1);
 		expect(delRes.structuredContent.skippedCount).toBe(1);

--- a/src/mcp/tests/memory.write.bulk.test.ts
+++ b/src/mcp/tests/memory.write.bulk.test.ts
@@ -146,6 +146,8 @@ describe("MCP Local Memory - memory-write BULK (memories[])", () => {
 			}
 		});
 
+		expect(bulkRes.isError).toBe(true);
+		expect(bulkRes.structuredContent).toMatchObject({ schema: "tool-error", code: "PARTIAL_FAILURE" });
 		expect(bulkRes.structuredContent.success).toBe(false);
 		expect(bulkRes.structuredContent.total).toBe(2);
 		expect(bulkRes.structuredContent.processed).toBe(1);

--- a/src/mcp/tests/metrics.test.ts
+++ b/src/mcp/tests/metrics.test.ts
@@ -100,10 +100,10 @@ describe("DurationSeries", () => {
 describe("MetricsRegistry", () => {
 	afterEach(() => metrics.reset());
 
-	it("records tool, write-handler, and embed-latency and snapshots them per key", () => {
+	it("records tool outcomes, write-handler, and embed-latency and snapshots them per key", () => {
 		const reg = createMetricsRegistry();
-		reg.recordTool("memory-read", 20);
-		reg.recordTool("memory-read", 40);
+		reg.recordTool("memory-read", 20, "success");
+		reg.recordTool("memory-read", 40, "error");
 		reg.recordWriteHandler("memory-write", 5);
 		reg.recordWriteHandler("memory-write", 15);
 		reg.recordEmbedLatency(30);
@@ -111,6 +111,7 @@ describe("MetricsRegistry", () => {
 		const snap = reg.snapshot();
 		expect(snap.tools["memory-read"].count).toBe(2);
 		expect(snap.tools["memory-read"].p50Ms).toBe(20);
+		expect(snap.toolOutcomes["memory-read"]).toEqual({ success: 1, error: 1, partial: 0, degraded: 0 });
 		expect(snap.writeHandler.total.count).toBe(2);
 		expect(snap.writeHandler.byTool["memory-write"].count).toBe(2);
 		expect(snap.embedLatency.count).toBe(1);

--- a/src/mcp/tests/migrations.kg-repo-identity-v33.test.ts
+++ b/src/mcp/tests/migrations.kg-repo-identity-v33.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { MigrationManager, SCHEMA_VERSION } from "../storage/migrations";
+
+describe("migration v33 KG repository identity", () => {
+	it("allows the same entity and relation identities in different repositories", () => {
+		const db = new Database(":memory:");
+		db.pragma("foreign_keys = ON");
+		new MigrationManager(db).migrate();
+
+		expect(SCHEMA_VERSION).toBe(33);
+		const now = new Date().toISOString();
+		const insertEntity = db.prepare(
+			"INSERT INTO entities (name, type, description, repo, owner, created_at, updated_at) VALUES (?, ?, NULL, ?, ?, ?, ?)"
+		);
+		for (const repo of ["repo-a", "repo-b"]) {
+			insertEntity.run("Shared", "concept", repo, "owner", now, now);
+			insertEntity.run("Target", "concept", repo, "owner", now, now);
+			db.prepare(
+				"INSERT INTO relations (from_entity, to_entity, relation_type, repo, owner, created_at, confidence) VALUES (?, ?, ?, ?, ?, ?, ?)"
+			).run("Shared", "Target", "uses", repo, "owner", now, 1);
+		}
+
+		expect(db.prepare("SELECT COUNT(*) AS count FROM entities WHERE name = 'Shared'").get()).toEqual({ count: 2 });
+		expect(db.prepare("SELECT COUNT(*) AS count FROM relations WHERE relation_type = 'uses'").get()).toEqual({
+			count: 2
+		});
+
+		db.prepare("INSERT INTO observations VALUES (?, ?, ?, ?, ?, ?)").run(
+			"repo-b-observation",
+			"Shared",
+			"Mentioned in memory: Shared",
+			"repo-b",
+			"owner",
+			now
+		);
+		db.prepare("DELETE FROM entities WHERE name = ? AND repo = ?").run("Shared", "repo-a");
+		expect(db.prepare("SELECT COUNT(*) AS count FROM entities WHERE name = 'Shared'").get()).toEqual({ count: 1 });
+		expect(db.prepare("SELECT COUNT(*) AS count FROM relations WHERE repo = 'repo-a'").get()).toEqual({ count: 0 });
+		expect(db.prepare("SELECT COUNT(*) AS count FROM relations WHERE repo = 'repo-b'").get()).toEqual({ count: 1 });
+		expect(db.prepare("SELECT COUNT(*) AS count FROM observations WHERE repo = 'repo-b'").get()).toEqual({ count: 1 });
+		expect(db.prepare("SELECT COUNT(*) AS count FROM entity_names_fts WHERE repo = 'repo-b'").get()).toEqual({
+			count: 2
+		});
+		db.prepare("UPDATE entities SET type = ? WHERE name = ? AND repo = ?").run("service", "Shared", "repo-b");
+		expect(db.prepare("SELECT name FROM entity_names_fts WHERE repo = 'repo-b' AND name = 'Shared'").get()).toEqual({
+			name: "Shared"
+		});
+		expect(db.prepare("SELECT degree FROM kg_degrees WHERE repo = 'repo-b' AND node = 'Shared'").get()).toEqual({
+			degree: 1
+		});
+		expect(db.pragma("foreign_key_check")).toEqual([]);
+		db.close();
+	});
+
+	it("rolls the entire rebuild back when historical graph data cannot satisfy the new foreign keys", () => {
+		const db = new Database(":memory:");
+		db.pragma("foreign_keys = ON");
+		new MigrationManager(db).migrate();
+		db.prepare("DELETE FROM _schema_version WHERE version = 33").run();
+		db.exec(
+			"DROP TRIGGER IF EXISTS entity_names_fts_ai; DROP TRIGGER IF EXISTS entity_names_fts_au; DROP TRIGGER IF EXISTS entity_names_fts_ad; DROP TABLE entity_names_fts;"
+		);
+		db.exec("DROP TRIGGER IF EXISTS trg_kg_degrees_ai; DROP TRIGGER IF EXISTS trg_kg_degrees_ad;");
+		db.exec("DROP TABLE observations; DROP TABLE relations; DROP TABLE entities;");
+		db.exec(`
+			CREATE TABLE entities (name TEXT PRIMARY KEY, type TEXT NOT NULL, description TEXT, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+			CREATE TABLE relations (from_entity TEXT NOT NULL, to_entity TEXT NOT NULL, relation_type TEXT NOT NULL, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL, confidence REAL, PRIMARY KEY(from_entity,to_entity,relation_type));
+			CREATE TABLE observations (id TEXT PRIMARY KEY, entity_name TEXT NOT NULL, observation TEXT NOT NULL, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL);
+		`);
+		const now = new Date().toISOString();
+		db.prepare("INSERT INTO entities VALUES (?, ?, NULL, ?, ?, ?, ?)").run(
+			"Known",
+			"concept",
+			"repo-a",
+			"owner",
+			now,
+			now
+		);
+		db.prepare("INSERT INTO relations VALUES (?, ?, ?, ?, ?, ?, NULL)").run(
+			"Known",
+			"Known",
+			"invalid",
+			"repo-a",
+			"owner",
+			now
+		);
+
+		// A malformed legacy NULL confidence violates the rebuilt table. The v33
+		// migration must fail and roll the entire schema replacement back.
+		expect(() => new MigrationManager(db).migrate()).toThrow();
+		expect(db.prepare("SELECT name FROM entities").all()).toEqual([{ name: "Known" }]);
+		expect(db.prepare("SELECT COUNT(*) AS count FROM _schema_version WHERE version = 33").get()).toEqual({ count: 0 });
+		db.close();
+	});
+
+	it("backfills one entity row per repository referenced by historical observations and relations", () => {
+		const db = new Database(":memory:");
+		db.pragma("foreign_keys = ON");
+		new MigrationManager(db).migrate();
+		const now = new Date().toISOString();
+
+		// Recreate the pre-v33 collision state, then rerun v33.
+		db.prepare("DELETE FROM _schema_version WHERE version = 33").run();
+		db.exec(
+			"DROP TRIGGER IF EXISTS entity_names_fts_ai; DROP TRIGGER IF EXISTS entity_names_fts_au; DROP TRIGGER IF EXISTS entity_names_fts_ad; DROP TABLE entity_names_fts;"
+		);
+		db.exec("DROP TRIGGER IF EXISTS trg_kg_degrees_ai; DROP TRIGGER IF EXISTS trg_kg_degrees_ad;");
+		db.exec("DROP TABLE observations; DROP TABLE relations; DROP TABLE entities;");
+		db.exec(`
+			CREATE TABLE entities (name TEXT PRIMARY KEY, type TEXT NOT NULL, description TEXT, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+			CREATE TABLE relations (from_entity TEXT NOT NULL, to_entity TEXT NOT NULL, relation_type TEXT NOT NULL, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL, confidence REAL NOT NULL DEFAULT 1.0, PRIMARY KEY(from_entity,to_entity,relation_type));
+			CREATE TABLE observations (id TEXT PRIMARY KEY, entity_name TEXT NOT NULL, observation TEXT NOT NULL, repo TEXT NOT NULL, owner TEXT NOT NULL, created_at TEXT NOT NULL);
+		`);
+		db.prepare("INSERT INTO entities VALUES (?, ?, NULL, ?, ?, ?, ?)").run(
+			"Shared",
+			"concept",
+			"repo-a",
+			"owner-a",
+			now,
+			now
+		);
+		db.prepare("INSERT INTO entities VALUES (?, ?, NULL, ?, ?, ?, ?)").run(
+			"Target",
+			"concept",
+			"repo-a",
+			"owner-a",
+			now,
+			now
+		);
+		db.prepare("INSERT INTO observations VALUES (?, ?, ?, ?, ?, ?)").run(
+			"obs-b",
+			"Shared",
+			"Mentioned in memory: B",
+			"repo-b",
+			"owner-b",
+			now
+		);
+		db.prepare("INSERT INTO relations VALUES (?, ?, ?, ?, ?, ?, ?)").run(
+			"Shared",
+			"Target",
+			"uses",
+			"repo-b",
+			"owner-b",
+			now,
+			0.8
+		);
+
+		new MigrationManager(db).migrate();
+		const rows = db.prepare("SELECT name, repo FROM entities ORDER BY name, repo").all();
+		expect(rows).toEqual([
+			{ name: "Shared", repo: "repo-a" },
+			{ name: "Shared", repo: "repo-b" },
+			{ name: "Target", repo: "repo-a" },
+			{ name: "Target", repo: "repo-b" }
+		]);
+		expect(db.pragma("foreign_key_check")).toEqual([]);
+		expect(db.prepare("SELECT COUNT(*) AS count FROM entity_names_fts").get()).toEqual({ count: 4 });
+		db.close();
+	});
+});

--- a/src/mcp/tests/migrations.relations-confidence-v24.test.ts
+++ b/src/mcp/tests/migrations.relations-confidence-v24.test.ts
@@ -63,7 +63,7 @@ describe("migration v24 relations confidence", () => {
 		const pk = db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'relations'").get() as {
 			sql: string;
 		};
-		expect(pk.sql).toContain("PRIMARY KEY (from_entity, to_entity, relation_type)");
+		expect(pk.sql).toContain("PRIMARY KEY (from_entity, to_entity, relation_type, repo)");
 
 		// NO confidence index is added. PRAGMA index_list (repo pattern — see
 		// migrations.standards.test.ts) lists the named CREATE INDEX entries

--- a/src/mcp/tests/migrations.relations-index-rebalance-v29.test.ts
+++ b/src/mcp/tests/migrations.relations-index-rebalance-v29.test.ts
@@ -196,7 +196,7 @@ describe("migration v29 KG relations index rebalance", () => {
 		const table = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='relations'").get() as {
 			sql: string;
 		};
-		expect(table.sql).toContain("PRIMARY KEY (from_entity, to_entity, relation_type)");
+		expect(table.sql).toContain("PRIMARY KEY (from_entity, to_entity, relation_type, repo)");
 
 		db.close();
 		fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/mcp/tests/query-tags.integration.test.ts
+++ b/src/mcp/tests/query-tags.integration.test.ts
@@ -252,7 +252,14 @@ describe("codebase-read multi-kind OR (TASK-445)", () => {
 		]);
 
 		const res = await handleCodebaseSearchMode(
-			{ query: "foo kind:function,class", owner: "", repo: "repok", offset: 0, limit: 10 } as CodebaseReadInput,
+			{
+				query: "foo kind:function,class",
+				owner: "",
+				repo: "repok",
+				offset: 0,
+				limit: 10,
+				json: true
+			} as CodebaseReadInput,
 			db,
 			vectors
 		);
@@ -268,7 +275,14 @@ describe("codebase-read multi-kind OR (TASK-445)", () => {
 			.mockReturnValue({ symbols: [], total: 0, hasMore: false });
 
 		await handleCodebaseSearchMode(
-			{ query: "foo kind:function,class", owner: "", repo: "repok", offset: 0, limit: 10 } as CodebaseReadInput,
+			{
+				query: "foo kind:function,class",
+				owner: "",
+				repo: "repok",
+				offset: 0,
+				limit: 10,
+				json: true
+			} as CodebaseReadInput,
 			db,
 			vectors
 		);

--- a/src/mcp/tests/reuse-telemetry.test.ts
+++ b/src/mcp/tests/reuse-telemetry.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createTestStore } from "../storage/sqlite";
+import { ReuseTelemetry } from "../utils/reuse-telemetry";
+
+const OWNER = "test-owner";
+const REPO = "telemetry-repo";
+
+function allocation() {
+	return {
+		tasks: { included: 1, excluded: 0, estimated_tokens: 40 },
+		decisions: { included: 0, excluded: 0, estimated_tokens: 0 },
+		handoffs: { included: 0, excluded: 0, estimated_tokens: 0 },
+		standards: { included: 0, excluded: 0, estimated_tokens: 0 },
+		observations: { included: 2, excluded: 1, estimated_tokens: 120 },
+		code: { included: 1, excluded: 0, estimated_tokens: 30 },
+		memories: { included: 0, excluded: 0, estimated_tokens: 0 }
+	};
+}
+
+describe("reuse telemetry", () => {
+	const stores: Awaited<ReturnType<typeof createTestStore>>[] = [];
+	afterEach(() => stores.splice(0).forEach((store) => store.close()));
+
+	it("migrates an aggregate-only schema and reapplies idempotently", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const columns = store.db.prepare("PRAGMA table_info(reuse_telemetry_hourly)").all() as Array<{ name: string }>;
+		expect(columns.map((column) => column.name)).toEqual([
+			"owner",
+			"repo",
+			"bucket",
+			"metric",
+			"source",
+			"count",
+			"value"
+		]);
+		expect(
+			store.db.prepare("SELECT name FROM sqlite_master WHERE name = 'idx_reuse_telemetry_scope_bucket'").get()
+		).toBeTruthy();
+	});
+
+	it("reconciles source allocation and stores no prompt or content columns", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const telemetry = new ReuseTelemetry(true);
+		telemetry.recordContextPack({
+			owner: OWNER,
+			repo: REPO,
+			session: "session-a",
+			packId: "pack-a",
+			cacheLookup: true,
+			cacheHit: false,
+			allocation: allocation(),
+			observationIds: ["obs-1", "obs-2"],
+			evidencePointers: 3,
+			staleRejected: 1
+		});
+		telemetry.flush(store);
+		const summary = store.reuseTelemetry.summarize(OWNER, REPO, 24);
+		expect(summary.metrics.context_items_included.count).toBe(4);
+		expect(summary.metrics.context_items_excluded.count).toBe(1);
+		expect(summary.metrics.context_estimated_tokens.value).toBe(190);
+		expect(summary.metrics.context_cache_misses.count).toBe(1);
+		expect(summary.metrics.observation_ids_reused.count).toBe(2);
+		expect(summary.metrics.evidence_pointers_reused.count).toBe(3);
+		expect(summary.metrics.observation_tokens_avoided.value).toBe(288);
+		const sql = store.db.prepare("SELECT sql FROM sqlite_master WHERE name = 'reuse_telemetry_hourly'").get() as {
+			sql: string;
+		};
+		expect(sql.sql).not.toMatch(/prompt|content|secret/i);
+	});
+
+	it("serves only explicitly keyed packs from the bounded cache", () => {
+		const telemetry = new ReuseTelemetry(true);
+		const packId = telemetry.createContextPackId(OWNER, REPO, "shared-key");
+		expect(telemetry.getCachedPack(packId)).toBeUndefined();
+		telemetry.cachePack(packId, { context_pack_id: packId });
+		expect(telemetry.getCachedPack(packId)).toEqual({ context_pack_id: packId });
+		expect(packId).not.toContain("shared-key");
+	});
+
+	it("counts repeated file/symbol reads within a hashed session window", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const telemetry = new ReuseTelemetry(true);
+		const base = { owner: OWNER, repo: REPO, session: "private-session", result: {} };
+		for (let index = 0; index < 2; index++) {
+			telemetry.recordTool({ ...base, toolName: "codebase-read", args: { filePath: "src/example.ts" } });
+			telemetry.recordTool({ ...base, toolName: "codebase-read", args: { name: "exampleSymbol" } });
+		}
+		telemetry.flush(store);
+		const metrics = store.reuseTelemetry.summarize(OWNER, REPO).metrics;
+		expect(metrics.file_reads.count).toBe(2);
+		expect(metrics.repeated_file_reads.count).toBe(1);
+		expect(metrics.symbol_reads.count).toBe(2);
+		expect(metrics.repeated_symbol_reads.count).toBe(1);
+	});
+
+	it("counts acknowledge/use only after the same session retrieved the memory", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const telemetry = new ReuseTelemetry(true);
+		const base = { owner: OWNER, repo: REPO, session: "session-a" };
+		telemetry.recordTool({
+			...base,
+			toolName: "memory-read",
+			args: { id: "memory-a" },
+			result: { structuredContent: { memory: { id: "memory-a" } } }
+		});
+		telemetry.recordTool({
+			...base,
+			toolName: "memory-write",
+			args: { id: "memory-a", acknowledge: "used" },
+			result: { structuredContent: { id: "memory-a" } }
+		});
+		telemetry.recordTool({
+			...base,
+			toolName: "memory-write",
+			args: { id: "never-read", acknowledge: "used" },
+			result: { structuredContent: { id: "never-read" } }
+		});
+		telemetry.flush(store);
+		expect(store.reuseTelemetry.summarize(OWNER, REPO).metrics.retrievals_acknowledged_used.count).toBe(1);
+	});
+
+	it("has a no-op disabled path with no buffered or persisted rows", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const telemetry = new ReuseTelemetry(false);
+		telemetry.recordTool({ owner: OWNER, repo: REPO, toolName: "codebase-read", args: { filePath: "x" }, result: {} });
+		telemetry.recordContextPack({
+			owner: OWNER,
+			repo: REPO,
+			packId: "pack",
+			cacheLookup: false,
+			cacheHit: false,
+			allocation: allocation(),
+			observationIds: [],
+			evidencePointers: 0,
+			staleRejected: 0
+		});
+		telemetry.flush(store);
+		expect(store.db.prepare("SELECT COUNT(*) AS count FROM reuse_telemetry_hourly").get()).toEqual({ count: 0 });
+	});
+
+	it("correlates claim to first useful task action", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		const telemetry = new ReuseTelemetry(true);
+		const base = { owner: OWNER, repo: REPO, session: "session-a", result: {} };
+		telemetry.recordTool({
+			...base,
+			toolName: "claim-manage",
+			args: { task_code: "TASK-1", agent: "worker" }
+		});
+		telemetry.recordTool({ ...base, toolName: "task-write", args: { task_code: "TASK-1", status: "in_progress" } });
+		telemetry.flush(store);
+		const metric = store.reuseTelemetry.summarize(OWNER, REPO).metrics.claim_to_first_action_ms;
+		expect(metric.count).toBe(1);
+		expect(metric.value).toBeGreaterThanOrEqual(0);
+	});
+
+	it("bounds persisted rows by retention cap", async () => {
+		const store = await createTestStore();
+		stores.push(store);
+		for (let index = 0; index < 40; index++) {
+			store.db
+				.prepare("INSERT INTO reuse_telemetry_hourly VALUES (?, ?, ?, ?, '', 1, 0)")
+				.run(OWNER, REPO, new Date(Date.now() - index * 3_600_000).toISOString(), `metric-${index}`);
+		}
+		store.reuseTelemetry.prune(365, 24);
+		expect(
+			(store.db.prepare("SELECT COUNT(*) AS count FROM reuse_telemetry_hourly").get() as { count: number }).count
+		).toBe(24);
+	});
+});

--- a/src/mcp/tests/runtime-capabilities.test.ts
+++ b/src/mcp/tests/runtime-capabilities.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { CapabilityAwareVectorStore } from "../storage/lazy-vectors";
+import {
+	RuntimeCapabilityRegistry,
+	getRuntimeCapabilities,
+	isSemanticToolDemand,
+	resolveRuntimeProfile,
+	setRuntimeCapabilities
+} from "../runtime-capabilities";
+import type { VectorStore } from "../types";
+
+describe("RuntimeCapabilityRegistry", () => {
+	it("defaults to full for backward compatibility and accepts explicit profiles", () => {
+		expect(resolveRuntimeProfile(undefined)).toBe("full");
+		expect(resolveRuntimeProfile("balanced")).toBe("balanced");
+		expect(resolveRuntimeProfile("minimal")).toBe("minimal");
+		expect(resolveRuntimeProfile("unknown")).toBe("full");
+	});
+
+	it("keeps semantic, indexing, watcher, and maintenance unavailable in minimal", async () => {
+		const registry = new RuntimeCapabilityRegistry("minimal");
+		const loader = vi.fn();
+		registry.register("semantic", loader);
+		expect(await registry.ensure("semantic")).toBe(false);
+		expect(loader).not.toHaveBeenCalled();
+		expect(registry.snapshot().capabilities.semantic.state).toBe("unavailable");
+	});
+
+	it("shares one initialization promise across concurrent first-use calls", async () => {
+		const registry = new RuntimeCapabilityRegistry("balanced");
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		const loader = vi.fn(() => gate);
+		registry.register("semantic", loader);
+		const first = registry.ensure("semantic");
+		const second = registry.ensure("semantic");
+		await Promise.resolve();
+		expect(loader).toHaveBeenCalledTimes(1);
+		release();
+		expect(await Promise.all([first, second])).toEqual([true, true]);
+		expect(registry.snapshot().capabilities.semantic.state).toBe("ready");
+	});
+
+	it("keeps balanced lazy and full explicitly warmable", async () => {
+		const balanced = new RuntimeCapabilityRegistry("balanced");
+		const balancedLoader = vi.fn();
+		balanced.register("semantic", balancedLoader);
+		expect(balanced.snapshot().capabilities.semantic.state).toBe("idle");
+		expect(balancedLoader).not.toHaveBeenCalled();
+
+		const full = new RuntimeCapabilityRegistry("full");
+		const fullLoader = vi.fn();
+		full.register("semantic", fullLoader);
+		await full.warmup(["semantic"]);
+		expect(fullLoader).toHaveBeenCalledTimes(1);
+		expect(full.snapshot().capabilities.semantic.state).toBe("ready");
+	});
+
+	it("recognizes semantic writes and query-bearing reads", () => {
+		expect(isSemanticToolDemand("memory-read", { query: "cache" })).toBe(true);
+		expect(isSemanticToolDemand("agent-context", { objective: "cache" })).toBe(true);
+		expect(isSemanticToolDemand("memory-write", { content: "cache" })).toBe(true);
+		expect(isSemanticToolDemand("task-read", {})).toBe(false);
+	});
+
+	it("exposes the active process registry to existing status surfaces", () => {
+		const registry = new RuntimeCapabilityRegistry("balanced");
+		setRuntimeCapabilities(registry);
+		expect(getRuntimeCapabilities()).toBe(registry);
+		setRuntimeCapabilities(new RuntimeCapabilityRegistry("full"));
+	});
+
+	it("lets legacy environment gates disable one capability without changing the profile", async () => {
+		const registry = new RuntimeCapabilityRegistry("full");
+		const loader = vi.fn();
+		registry.register("watcher", loader);
+		registry.disable("watcher", "Disabled via ENABLE_FILE_WATCHER=false");
+		expect(await registry.ensure("watcher")).toBe(false);
+		expect(loader).not.toHaveBeenCalled();
+		expect(registry.snapshot().capabilities.watcher).toMatchObject({
+			state: "unavailable",
+			error: "Disabled via ENABLE_FILE_WATCHER=false"
+		});
+	});
+
+	it("reports a missing loader as degraded instead of pretending it is ready", async () => {
+		const registry = new RuntimeCapabilityRegistry("balanced");
+		expect(await registry.ensure("indexing")).toBe(false);
+		expect(registry.snapshot().capabilities.indexing).toMatchObject({
+			state: "degraded",
+			error: "No capability loader registered"
+		});
+	});
+
+	it("isolates failures and retries a transient initialization on next demand", async () => {
+		const registry = new RuntimeCapabilityRegistry("full");
+		const loader = vi.fn().mockRejectedValueOnce(new Error("model unavailable")).mockResolvedValueOnce(undefined);
+		registry.register("semantic", loader);
+		expect(await registry.ensure("semantic")).toBe(false);
+		const failed = registry.snapshot();
+		expect(failed.capabilities.semantic).toMatchObject({ state: "failed", error: "model unavailable" });
+		expect(failed.capabilities.indexing.state).toBe("idle");
+		expect(failed.footprint.rss_bytes).toBeGreaterThan(0);
+		expect(await registry.ensure("semantic")).toBe(true);
+		expect(loader).toHaveBeenCalledTimes(2);
+		expect(registry.snapshot().capabilities.semantic.state).toBe("ready");
+	});
+});
+
+describe("CapabilityAwareVectorStore", () => {
+	function makeInner(): VectorStore {
+		return {
+			initialize: vi.fn().mockResolvedValue(undefined),
+			embed: vi.fn().mockResolvedValue([[1, 0]]),
+			upsert: vi.fn().mockResolvedValue(undefined),
+			remove: vi.fn().mockResolvedValue(undefined),
+			search: vi.fn().mockResolvedValue([{ id: "m1", score: 1 }])
+		};
+	}
+
+	it("keeps lexical paths operational when semantic is unavailable", async () => {
+		const registry = new RuntimeCapabilityRegistry("minimal");
+		const inner = makeInner();
+		const vectors = new CapabilityAwareVectorStore(inner, registry);
+		expect(await vectors.search("query", 5)).toEqual([]);
+		expect(await vectors.embed(["text"])).toEqual([]);
+		expect(inner.search).not.toHaveBeenCalled();
+		expect(inner.embed).not.toHaveBeenCalled();
+	});
+
+	it("loads semantic once and delegates first-use operations in balanced", async () => {
+		const registry = new RuntimeCapabilityRegistry("balanced");
+		const inner = makeInner();
+		registry.register("semantic", () => inner.initialize?.());
+		const vectors = new CapabilityAwareVectorStore(inner, registry);
+		await Promise.all([vectors.search("query", 5), vectors.search("other", 5)]);
+		expect(inner.initialize).toHaveBeenCalledTimes(1);
+		expect(inner.search).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/mcp/tests/sdk-resources.test.ts
+++ b/src/mcp/tests/sdk-resources.test.ts
@@ -80,6 +80,19 @@ async function connectServer() {
 }
 
 describe("SDK resource discovery (TASK-442 OpenCode compatibility)", () => {
+	it("keeps canonical tools discoverable through the SDK transport", async () => {
+		const { client, server, db } = await connectServer();
+		try {
+			const listed = await client.listTools();
+			expect(listed.tools.map((tool) => tool.name)).toContain("codebase-index");
+			expect(listed.tools.length).toBeGreaterThan(0);
+		} finally {
+			await client.close();
+			await server.close();
+			db.close();
+		}
+	});
+
 	it("advertises the resources capability in the initialize handshake", async () => {
 		const { client, server, db } = await connectServer();
 		try {

--- a/src/mcp/tests/standard.delete.test.ts
+++ b/src/mcp/tests/standard.delete.test.ts
@@ -167,6 +167,8 @@ describe("MCP Local Memory - Standard Delete", () => {
 			}
 		});
 
+		expect(delRes.isError).toBe(true);
+		expect(delRes.structuredContent).toMatchObject({ schema: "tool-error", code: "PARTIAL_FAILURE" });
 		expect(delRes.structuredContent.success).toBe(true);
 		expect(delRes.structuredContent.deletedCount).toBe(1);
 		expect(delRes.structuredContent.skippedCount).toBe(1);

--- a/src/mcp/tests/tasks.bulk.mutate.test.ts
+++ b/src/mcp/tests/tasks.bulk.mutate.test.ts
@@ -371,6 +371,8 @@ describe("MCP Local Memory - Consolidated Task Tools Bulk (update / soft-delete 
 		})) as McpResponse;
 
 		const data = delRes.structuredContent as any;
+		expect(delRes.isError).toBe(true);
+		expect(data).toMatchObject({ schema: "tool-error", code: "PARTIAL_FAILURE" });
 		expect(data.success).toBe(true);
 		expect(data.canceledCount).toBe(1);
 		expect(data.skippedCount).toBe(1);
@@ -418,6 +420,8 @@ describe("MCP Local Memory - Consolidated Task Tools Bulk (update / soft-delete 
 		// The shared success formula `deletedCount > 0 || skippedCount === 0`
 		// flips to false here — nothing was deleted and everything was skipped.
 		const data = delRes.structuredContent as any;
+		expect(delRes.isError).toBe(true);
+		expect(data).toMatchObject({ schema: "tool-error", code: "BULK_OPERATION_FAILED" });
 		expect(data.success).toBe(false);
 		expect(data.canceledCount).toBe(0);
 		expect(data.skippedCount).toBe(2);

--- a/src/mcp/tests/tasks.bulk.test.ts
+++ b/src/mcp/tests/tasks.bulk.test.ts
@@ -362,6 +362,7 @@ describe("MCP Local Memory - Consolidated Task Tools Bulk Operations (create / l
 		});
 		// Partial failure returns isError with structuredContent containing results
 		expect(res.isError).toBe(true);
+		expect(res.structuredContent).toMatchObject({ schema: "tool-error", code: "PARTIAL_FAILURE" });
 		expect(res.structuredContent.createdCount).toBe(2);
 		expect(res.structuredContent.total).toBe(3);
 		expect(res.structuredContent.errors).toBeDefined();

--- a/src/mcp/tests/tool-plumbing.test.ts
+++ b/src/mcp/tests/tool-plumbing.test.ts
@@ -28,7 +28,8 @@ describe("WRITE_TOOLS — write-lock membership", () => {
 				"standard-write",
 				"standard-delete",
 				"task-write",
-				"task-delete"
+				"task-delete",
+				"observation-write"
 			])
 		);
 	});

--- a/src/mcp/tests/utils/mcp-response.test.ts
+++ b/src/mcp/tests/utils/mcp-response.test.ts
@@ -3,6 +3,7 @@ import {
 	createMcpResponse,
 	createTextOnlyResponse,
 	buildTableResult,
+	withEnvelope,
 	getPrimaryTextContent,
 	isMcpResponse,
 	McpContentSchema,
@@ -108,9 +109,11 @@ describe("createMcpResponse", () => {
 		expect(data).toEqual({ id: "1", hit_count: 9, title: "t" });
 	});
 
-	it("leaves content empty when summary and contentSummary are both blank", () => {
-		const response = createMcpResponse({ id: "1" }, "");
-		expect(response.content).toEqual([]);
+	it("keeps a concise non-empty text item when summaries are blank", () => {
+		const response = createMcpResponse({ id: "1" }, "", { includeJson: true });
+		expect(response.content).toEqual([
+			{ type: "text", text: "Request completed. Read structuredContent for machine-readable results." }
+		]);
 	});
 });
 
@@ -132,6 +135,7 @@ describe("buildTableResult", () => {
 	it("nests the table under key and merges schema, pagination and extra", () => {
 		const result = buildTableResult(["id"], [["1"]], {
 			schema: "task-read",
+			mode: "list",
 			key: "tasks",
 			total: 10,
 			offset: 5,
@@ -141,6 +145,7 @@ describe("buildTableResult", () => {
 		});
 		expect(result).toEqual({
 			schema: "task-read",
+			mode: "list",
 			query: "q",
 			tasks: { columns: ["id"], rows: [["1"]] },
 			count: 1,
@@ -162,6 +167,21 @@ describe("buildTableResult", () => {
 		expect(result.columns).toEqual(["id"]);
 		expect(result.columns).not.toBe(columns);
 		expect(result.rows).toBe(rows);
+	});
+});
+
+describe("withEnvelope", () => {
+	it("adds stable discriminators without duplicating or renaming legacy fields", () => {
+		const item = { id: "1", title: "kept-at-the-legacy-path" };
+		const result = withEnvelope("memory-read", "detail", { memory: item, stats: { hitCount: 2 } });
+
+		expect(result).toEqual({
+			schema: "memory-read",
+			mode: "detail",
+			memory: item,
+			stats: { hitCount: 2 }
+		});
+		expect(result).not.toHaveProperty("item");
 	});
 });
 

--- a/src/mcp/tools/agent-context-compiler.ts
+++ b/src/mcp/tools/agent-context-compiler.ts
@@ -1,0 +1,190 @@
+import type { CodebaseSymbol, CodingStandardEntry, ExplorationObservation, Handoff, MemoryEntry, Task } from "../types";
+import { TASK_STATUS_IN_PROGRESS } from "../types";
+
+export const AGENT_CONTEXT_SOURCE_ORDER = [
+	"tasks",
+	"decisions",
+	"handoffs",
+	"standards",
+	"observations",
+	"code",
+	"memories"
+] as const;
+export type AgentContextSource = (typeof AGENT_CONTEXT_SOURCE_ORDER)[number];
+
+export interface ContextCandidate {
+	source: AgentContextSource;
+	id: string;
+	title: string;
+	text: string;
+	provenance: Record<string, unknown>;
+	priority: number;
+	critical: boolean;
+	estimated_tokens: number;
+}
+
+export interface ContextExclusion {
+	source: AgentContextSource;
+	id: string;
+	reason: "token_budget" | "item_budget";
+	estimated_tokens: number;
+}
+
+function estimateTokens(text: string): number {
+	return Math.max(12, Math.ceil(text.length / 4) + 8);
+}
+
+function lexicalScore(text: string, objective: string): number {
+	const terms = [
+		...new Set(
+			objective
+				.toLocaleLowerCase("en-US")
+				.split(/[^a-z0-9_/-]+/)
+				.filter((term) => term.length > 1)
+		)
+	];
+	if (terms.length === 0) return 0;
+	const normalized = text.toLocaleLowerCase("en-US");
+	return terms.filter((term) => normalized.includes(term)).length / terms.length;
+}
+
+function candidate(
+	source: AgentContextSource,
+	id: string,
+	title: string,
+	text: string,
+	priority: number,
+	critical: boolean,
+	provenance: Record<string, unknown>
+): ContextCandidate {
+	return {
+		source,
+		id,
+		title,
+		text,
+		priority,
+		critical,
+		provenance,
+		estimated_tokens: estimateTokens(`${title}: ${text}`)
+	};
+}
+
+export function rankAndPackContext(
+	candidates: ContextCandidate[],
+	objective: string,
+	budget: { tokens: number; max_items: number }
+): { included: ContextCandidate[]; exclusions: ContextExclusion[]; estimatedTokens: number } {
+	const sourceRank = new Map(AGENT_CONTEXT_SOURCE_ORDER.map((source, index) => [source, index]));
+	const ranked = [...candidates].sort((a, b) => {
+		if (a.critical !== b.critical) return a.critical ? -1 : 1;
+		const valueA = (a.priority + lexicalScore(`${a.title} ${a.text}`, objective) * 5) / a.estimated_tokens;
+		const valueB = (b.priority + lexicalScore(`${b.title} ${b.text}`, objective) * 5) / b.estimated_tokens;
+		return (
+			valueB - valueA || (sourceRank.get(a.source) ?? 99) - (sourceRank.get(b.source) ?? 99) || a.id.localeCompare(b.id)
+		);
+	});
+	const included: ContextCandidate[] = [];
+	const exclusions: ContextExclusion[] = [];
+	let estimatedTokens = 0;
+	for (const item of ranked) {
+		const reason =
+			included.length >= budget.max_items
+				? "item_budget"
+				: estimatedTokens + item.estimated_tokens > budget.tokens
+					? "token_budget"
+					: null;
+		if (reason) {
+			exclusions.push({ source: item.source, id: item.id, reason, estimated_tokens: item.estimated_tokens });
+			continue;
+		}
+		included.push(item);
+		estimatedTokens += item.estimated_tokens;
+	}
+	return { included, exclusions, estimatedTokens };
+}
+
+export function memoryCandidate(memory: MemoryEntry, source: "memories" | "decisions"): ContextCandidate {
+	return candidate(
+		source,
+		memory.id,
+		memory.title,
+		memory.content.slice(0, 600),
+		memory.importance,
+		source === "decisions",
+		{
+			code: memory.code ?? null,
+			type: memory.type,
+			updated_at: memory.updated_at
+		}
+	);
+}
+
+export function taskCandidate(task: Task, requestedTaskCode?: string): ContextCandidate {
+	return candidate(
+		"tasks",
+		task.task_code,
+		task.title,
+		task.description?.slice(0, 500) ?? `${task.phase} · ${task.status}`,
+		task.priority + (task.status === TASK_STATUS_IN_PROGRESS ? 2 : 0),
+		task.task_code === requestedTaskCode,
+		{ task_id: task.id, status: task.status, priority: task.priority, updated_at: task.updated_at }
+	);
+}
+
+export function handoffCandidate(handoff: Handoff): ContextCandidate {
+	return candidate(
+		"handoffs",
+		handoff.id,
+		`Handoff from ${handoff.from_agent}`,
+		handoff.summary.slice(0, 500),
+		4,
+		false,
+		{
+			task_code: handoff.task_code ?? null,
+			to_agent: handoff.to_agent,
+			created_at: handoff.created_at
+		}
+	);
+}
+
+export function standardCandidate(standard: CodingStandardEntry): ContextCandidate {
+	return candidate(
+		"standards",
+		standard.code ?? standard.id,
+		standard.title,
+		standard.content.slice(0, 500),
+		3,
+		false,
+		{
+			code: standard.code ?? null,
+			language: standard.language,
+			version: standard.version
+		}
+	);
+}
+
+export function observationCandidate(observation: ExplorationObservation): ContextCandidate {
+	return candidate(
+		"observations",
+		observation.id,
+		observation.subject,
+		observation.fact.slice(0, 500),
+		observation.confidence * 5,
+		false,
+		{
+			confidence: observation.confidence,
+			freshness: observation.freshness,
+			task_id: observation.task_id,
+			evidence_count: observation.evidence_count
+		}
+	);
+}
+
+export function codeCandidate(symbol: CodebaseSymbol): ContextCandidate {
+	return candidate("code", symbol.id, symbol.name, symbol.signature ?? symbol.kind, symbol.exported ? 4 : 2, false, {
+		file_path: symbol.file_path,
+		kind: symbol.kind,
+		start_line: symbol.start_line,
+		end_line: symbol.end_line
+	});
+}

--- a/src/mcp/tools/agent-context.ts
+++ b/src/mcp/tools/agent-context.ts
@@ -1,14 +1,19 @@
 import { AgentContextSchema } from "./schemas/index";
 import { SQLiteStore } from "../storage/sqlite";
+import type { MemoryEntry, VectorStore } from "../types";
+import { TASK_STATUS_IN_PROGRESS, TASK_STATUS_PENDING, TASK_STATUS_BACKLOG, TASK_STATUS_BLOCKED } from "../types";
 import {
-	MemoryEntry,
-	Task,
-	VectorStore,
-	TASK_STATUS_IN_PROGRESS,
-	TASK_STATUS_PENDING,
-	TASK_STATUS_BACKLOG,
-	TASK_STATUS_BLOCKED
-} from "../types";
+	AGENT_CONTEXT_SOURCE_ORDER,
+	codeCandidate,
+	handoffCandidate,
+	memoryCandidate,
+	observationCandidate,
+	rankAndPackContext,
+	standardCandidate,
+	taskCandidate,
+	type AgentContextSource,
+	type ContextCandidate
+} from "./agent-context-compiler";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
 import { logger } from "../utils/logger";
 
@@ -33,160 +38,190 @@ export async function handleAgentContext(
 	vectors: VectorStore
 ): Promise<McpResponse> {
 	const validated = AgentContextSchema.parse(args);
-	const { owner, repo, query, type_filter, limit, json: isJsonRequest } = validated;
-
-	// 1. Search for relevant memories
-	let memories: MemoryEntry[];
+	const { owner, repo, type_filter, limit, json: isJsonRequest } = validated;
+	const objective = validated.objective ?? validated.query ?? "";
+	const enabled = new Set<AgentContextSource>(validated.sources);
+	const candidateLimit = Math.min(100, Math.max(limit, validated.budget.max_items * 2));
+	let memories: MemoryEntry[] = [];
 	let decisionMemories: MemoryEntry[] = [];
 
-	const shouldFetchDecisions = !type_filter || type_filter === "decision";
-
-	if (query) {
-		// Primary: vector search with hybrid scoring per SPEC-001
-		try {
-			const vectorResults = await vectors.search(query, limit, repo);
-			if (vectorResults.length > 0) {
-				const ids = vectorResults.map((r) => r.id);
-				const idSet = new Set(ids);
-				// Build vector score map for hybrid scoring
-				const vectorScoreMap = new Map<string, number>();
-				for (const vr of vectorResults) {
-					vectorScoreMap.set(vr.id, vr.score);
-				}
-				// Bulk-fetch in a single query (TASK-023), preserving vector rank order
-				const fetched = db.memories.getByIds(ids);
-				const fetchedById = new Map(fetched.map((m) => [m.id, m]));
-				memories = ids
-					.map((id) => fetchedById.get(id))
-					.filter((m): m is MemoryEntry => m !== undefined && idSet.has(m.id));
-				// Apply type_filter post-hoc if set
-				if (type_filter) {
-					memories = memories.filter((m) => m.type === type_filter);
-				}
-				// Apply hybrid scoring: final = (vector × 0.30) + (importance/5 × 0.70)
-				// — deliberate divergence from SPEC-001, see AGENT_CONTEXT_BLEND.
+	if (enabled.has("memories")) {
+		if (objective) {
+			try {
+				const vectorResults = await vectors.search(objective, candidateLimit, repo);
+				const vectorScores = new Map(vectorResults.map((result) => [result.id, result.score]));
+				const byId = new Map(
+					db.memories.getByIds(vectorResults.map((result) => result.id)).map((memory) => [memory.id, memory])
+				);
+				memories = vectorResults
+					.map((result) => byId.get(result.id))
+					.filter((item): item is MemoryEntry => Boolean(item));
+				if (type_filter) memories = memories.filter((memory) => memory.type === type_filter);
 				memories.sort((a, b) => {
-					const vecA = vectorScoreMap.get(a.id) ?? 0;
-					const vecB = vectorScoreMap.get(b.id) ?? 0;
-					const importanceA = (a.importance ?? 3) / 5;
-					const importanceB = (b.importance ?? 3) / 5;
-					const blendedA = vecA * AGENT_CONTEXT_BLEND.vector + importanceA * AGENT_CONTEXT_BLEND.importance;
-					const blendedB = vecB * AGENT_CONTEXT_BLEND.vector + importanceB * AGENT_CONTEXT_BLEND.importance;
-					return blendedB - blendedA;
+					const score = (memory: MemoryEntry) =>
+						(vectorScores.get(memory.id) ?? 0) * AGENT_CONTEXT_BLEND.vector +
+						((memory.importance ?? 3) / 5) * AGENT_CONTEXT_BLEND.importance;
+					return score(b) - score(a) || a.id.localeCompare(b.id);
 				});
-			} else {
-				memories = db.memories.searchByRepo(owner, repo, query, type_filter, limit);
+				if (memories.length === 0)
+					memories = db.memories.searchByRepo(owner, repo, objective, type_filter, candidateLimit);
+			} catch {
+				logger.warn("[Tool] agent-context vector search failed, falling back to keyword", { repo });
+				memories = db.memories.searchByRepo(owner, repo, objective, type_filter, candidateLimit);
 			}
-		} catch {
-			logger.warn("[Tool] agent-context vector search failed, falling back to keyword", { repo });
-			memories = db.memories.searchByRepo(owner, repo, query, type_filter, limit);
+		} else {
+			const excludeTypes: string[] = type_filter ? [] : ["decision"];
+			memories = db.memories.getRecentMemories(owner, repo, candidateLimit, 0, false, excludeTypes);
+			if (type_filter) memories = memories.filter((memory) => memory.type === type_filter);
 		}
-		if (shouldFetchDecisions) {
-			decisionMemories = db.memories.searchByRepo(owner, repo, "", "decision", limit);
-		}
-	} else {
-		const excludeTypes: string[] = type_filter ? [] : ["decision"];
-		memories = db.memories.getRecentMemories(owner, repo, limit, 0, false, excludeTypes);
-		if (type_filter) {
-			memories = memories.filter((m) => m.type === type_filter);
-		}
-		if (shouldFetchDecisions) {
-			decisionMemories = db.memories.searchByRepo(owner, repo, "", "decision", limit);
+	}
+	if (enabled.has("decisions") && (!type_filter || type_filter === "decision")) {
+		decisionMemories = db.memories.searchByRepo(owner, repo, objective, "decision", candidateLimit);
+	}
+
+	const activeTasks = enabled.has("tasks")
+		? db.tasks.getTasksByMultipleStatuses(owner, repo, ACTIVE_TASK_STATUSES, candidateLimit, 0, objective || undefined)
+		: [];
+	if (
+		enabled.has("tasks") &&
+		validated.task_code &&
+		!activeTasks.some((task) => task.task_code === validated.task_code)
+	) {
+		const requested = db.tasks.getTaskByCode(owner, repo, validated.task_code);
+		if (requested) activeTasks.unshift(requested);
+	}
+	const handoffs = enabled.has("handoffs")
+		? db.handoffs.listHandoffs({ owner, repo, status: "pending", limit: candidateLimit, offset: 0 })
+		: [];
+	const standards = enabled.has("standards")
+		? db.standards.search({ query: objective || undefined, owner, repo, limit: candidateLimit, offset: 0 })
+		: [];
+	const observations = enabled.has("observations")
+		? db.explorationObservations.list({
+				owner,
+				repo,
+				include_stale: validated.include_stale,
+				limit: candidateLimit,
+				offset: 0
+			})
+		: [];
+	const codeSymbols =
+		enabled.has("code") && validated.current_file_path
+			? db.codebaseSymbols.getSymbolsByFile(repo, validated.current_file_path).slice(0, candidateLimit)
+			: [];
+	if (enabled.has("code") && validated.current_file_path && validated.budget.code_depth > 0) {
+		const symbolIds = new Set(codeSymbols.map((symbol) => symbol.id));
+		let frontier = [validated.current_file_path];
+		for (let depth = 0; depth < validated.budget.code_depth && frontier.length > 0; depth++) {
+			const nextFiles = new Set<string>();
+			for (const filePath of frontier.sort()) {
+				for (const reference of db.codebaseReferences.getReferencesByFile(repo, filePath).slice(0, candidateLimit)) {
+					const targetSymbols = reference.target_file
+						? db.codebaseSymbols.getSymbolsByFile(repo, reference.target_file)
+						: db.codebaseSymbols.getSymbolByName(repo, reference.symbol_name);
+					const referenced = reference.target_symbol_id
+						? targetSymbols.find((symbol) => symbol.id === reference.target_symbol_id)
+						: targetSymbols.find((symbol) => symbol.name === reference.symbol_name);
+					if (referenced && !symbolIds.has(referenced.id)) {
+						codeSymbols.push(referenced);
+						symbolIds.add(referenced.id);
+					}
+					if (reference.target_file) nextFiles.add(reference.target_file);
+					if (codeSymbols.length >= candidateLimit) break;
+				}
+				if (codeSymbols.length >= candidateLimit) break;
+			}
+			frontier = [...nextFiles];
 		}
 	}
 
-	// 2. Get active tasks
-	const activeTasks = db.tasks.getTasksByMultipleStatuses(owner, repo, ACTIVE_TASK_STATUSES, 10, 0);
+	const memoryIds = new Set(memories.map((memory) => memory.id));
+	const uniqueDecisions = decisionMemories.filter((decision) => !memoryIds.has(decision.id));
+	const candidates: ContextCandidate[] = [];
+	memories.forEach((memory) => candidates.push(memoryCandidate(memory, "memories")));
+	uniqueDecisions.forEach((decision) => candidates.push(memoryCandidate(decision, "decisions")));
+	activeTasks.forEach((task) => candidates.push(taskCandidate(task, validated.task_code)));
+	handoffs.forEach((handoff) => candidates.push(handoffCandidate(handoff)));
+	standards.forEach((standard) => candidates.push(standardCandidate(standard)));
+	observations.forEach((observation) => candidates.push(observationCandidate(observation)));
+	codeSymbols.forEach((symbol) => candidates.push(codeCandidate(symbol)));
+	const packed = rankAndPackContext(candidates, objective, validated.budget);
+	// Keep the legacy projections independent from compiler packing so existing
+	// consumers do not lose rows merely because another source won the budget.
+	const selectedMemories = memories.slice(0, limit);
+	const selectedDecisions = uniqueDecisions.slice(0, limit);
+	const selectedTasks = activeTasks.slice(0, 10);
 
-	// 3. Deduplicate: remove any decision memories already in the general memories list
-	const memoryIds = new Set(memories.map((m) => m.id));
-	const uniqueDecisions = decisionMemories.filter((d) => !memoryIds.has(d.id));
-
-	// 4. Build formatted context block
-	const sections: string[] = [];
+	const sections = [`--- Active Context for "${repo}" ---`, "", "== Relevant Memories =="];
 	sections.push(
-		`--- Active Context for "${repo}" --- (${memories.length} memories, ${activeTasks.length} tasks, ${uniqueDecisions.length} decisions)`
+		...(selectedMemories.length
+			? selectedMemories.map((memory) => `- [${memory.code || "-"}] ${memory.title}: ${memory.content.slice(0, 120)}`)
+			: ["(No relevant memories selected)"])
 	);
-	sections.push("");
-
-	// Memories section
-	sections.push("== Relevant Memories ==");
-	if (memories.length === 0) {
-		sections.push("(No relevant memories found)");
-	} else {
-		for (const m of memories) {
-			const code = m.code || "-";
-			const snippet = m.content.length > 120 ? m.content.slice(0, 120) + "..." : m.content;
-			sections.push(`- [${code}] (${m.type}, importance: ${m.importance}) ${m.title}`);
-			sections.push(`  ${snippet}`);
-		}
-	}
-	sections.push("");
-
-	// Active Tasks section
-	sections.push("== Active Tasks ==");
-	if (activeTasks.length === 0) {
-		sections.push("(No active tasks)");
-	} else {
-		for (const t of activeTasks) {
-			sections.push(`- ${t.task_code} | ${t.status} | priority: ${t.priority} | ${t.title}`);
-		}
-	}
-	sections.push("");
-
-	// Recent Decisions section
-	sections.push("== Recent Decisions ==");
-	if (uniqueDecisions.length === 0) {
-		sections.push("(No recent decision memories)");
-	} else {
-		for (const d of uniqueDecisions) {
-			const code = d.code || "-";
-			const snippet = d.content.length > 150 ? d.content.slice(0, 150) + "..." : d.content;
-			sections.push(`- [${code}] (importance: ${d.importance}) ${d.title}`);
-			sections.push(`  ${snippet}`);
-		}
-	}
-	sections.push("");
-	if (memories.length > 0 || activeTasks.length > 0 || uniqueDecisions.length > 0) {
-		sections.push("Use memory-detail with a memory code for full content.");
-	}
-
+	sections.push("", "== Compiled Context ==");
+	sections.push(
+		...(packed.included.length
+			? packed.included.map((item) => `- [${item.source}/${item.id}] ${item.title}: ${item.text.slice(0, 180)}`)
+			: ["(No candidates fit the requested budget)"])
+	);
+	sections.push(
+		"",
+		`Estimated ${packed.estimatedTokens}/${validated.budget.tokens} tokens across ${packed.included.length} items.`
+	);
 	const contentSummary = sections.join("\n").trim();
-
+	const sourceAllocation = Object.fromEntries(
+		AGENT_CONTEXT_SOURCE_ORDER.map((source) => [
+			source,
+			{
+				included: packed.included.filter((item) => item.source === source).length,
+				excluded: packed.exclusions.filter((item) => item.source === source).length,
+				estimated_tokens: packed.included
+					.filter((item) => item.source === source)
+					.reduce((sum, item) => sum + item.estimated_tokens, 0)
+			}
+		])
+	);
 	const structuredData = {
 		schema: "agent-context" as const,
+		mode: "compiled" as const,
 		repo,
-		query: query || null,
-		memories: memories.map((m) => ({
-			id: m.id,
-			code: m.code || null,
-			title: m.title,
-			type: m.type,
-			importance: m.importance
+		query: objective || null,
+		objective: objective || null,
+		memories: selectedMemories.map((memory) => ({
+			id: memory.id,
+			code: memory.code || null,
+			title: memory.title,
+			type: memory.type,
+			importance: memory.importance
 		})),
-		decisions: uniqueDecisions.map((d) => ({
-			id: d.id,
-			code: d.code || null,
-			title: d.title,
-			importance: d.importance
+		decisions: selectedDecisions.map((decision) => ({
+			id: decision.id,
+			code: decision.code || null,
+			title: decision.title,
+			importance: decision.importance
 		})),
-		tasks: activeTasks.map((t: Task) => ({
-			task_code: t.task_code,
-			title: t.title,
-			status: t.status,
-			priority: t.priority
-		}))
+		tasks: selectedTasks.map((task) => ({
+			task_code: task.task_code,
+			title: task.title,
+			status: task.status,
+			priority: task.priority
+		})),
+		context: packed.included.map(({ priority: _priority, critical: _critical, ...item }) => item),
+		estimated_tokens: packed.estimatedTokens,
+		budget: validated.budget,
+		allocation: {
+			included_items: packed.included.length,
+			excluded_items: packed.exclusions.length,
+			sources: sourceAllocation
+		},
+		exclusions: packed.exclusions
 	};
 
 	logger.info("[Tool] agent-context", {
 		repo,
-		memories: memories.length,
-		decisions: uniqueDecisions.length,
-		tasks: activeTasks.length
+		included: packed.included.length,
+		excluded: packed.exclusions.length,
+		estimatedTokens: packed.estimatedTokens
 	});
-
-	return createMcpResponse(structuredData, contentSummary, {
-		contentSummary,
-		includeJson: isJsonRequest
-	});
+	return createMcpResponse(structuredData, contentSummary, { contentSummary, includeJson: isJsonRequest });
 }

--- a/src/mcp/tools/agent-context.ts
+++ b/src/mcp/tools/agent-context.ts
@@ -16,6 +16,7 @@ import {
 } from "./agent-context-compiler";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
 import { logger } from "../utils/logger";
+import { reuseTelemetry } from "../utils/reuse-telemetry";
 
 const ACTIVE_TASK_STATUSES = [TASK_STATUS_IN_PROGRESS, TASK_STATUS_PENDING, TASK_STATUS_BACKLOG, TASK_STATUS_BLOCKED];
 
@@ -40,6 +41,42 @@ export async function handleAgentContext(
 	const validated = AgentContextSchema.parse(args);
 	const { owner, repo, type_filter, limit, json: isJsonRequest } = validated;
 	const objective = validated.objective ?? validated.query ?? "";
+	const packCorrelation = [
+		validated.context_pack_id ?? validated.session_id ?? "anonymous",
+		objective,
+		validated.task_code ?? "",
+		validated.current_file_path ?? "",
+		validated.sources.join(","),
+		JSON.stringify(validated.budget),
+		String(validated.include_stale),
+		String(isJsonRequest)
+	].join("\u001f");
+	const contextPackId = reuseTelemetry.createContextPackId(owner, repo, packCorrelation);
+	type CachedContextPack = {
+		response: McpResponse;
+		allocation: Record<AgentContextSource, { included: number; excluded: number; estimated_tokens: number }>;
+		observationIds: string[];
+		memoryIds: string[];
+		evidencePointers: number;
+	};
+	const cached = validated.context_pack_id ? reuseTelemetry.getCachedPack<CachedContextPack>(contextPackId) : undefined;
+	if (cached) {
+		reuseTelemetry.recordContextPack({
+			owner,
+			repo,
+			session: validated.session_id,
+			packId: contextPackId,
+			cacheLookup: true,
+			cacheHit: true,
+			allocation: cached.allocation,
+			observationIds: cached.observationIds,
+			memoryIds: cached.memoryIds,
+			evidencePointers: cached.evidencePointers,
+			staleRejected: 0
+		});
+		reuseTelemetry.flushIfNeeded(db);
+		return cached.response;
+	}
 	const enabled = new Set<AgentContextSource>(validated.sources);
 	const candidateLimit = Math.min(100, Math.max(limit, validated.budget.max_items * 2));
 	let memories: MemoryEntry[] = [];
@@ -180,10 +217,21 @@ export async function handleAgentContext(
 					.reduce((sum, item) => sum + item.estimated_tokens, 0)
 			}
 		])
-	);
+	) as Record<AgentContextSource, { included: number; excluded: number; estimated_tokens: number }>;
+	const observationIds = packed.included.filter((item) => item.source === "observations").map((item) => item.id);
+	const evidencePointers = packed.included
+		.filter((item) => item.source === "observations")
+		.reduce((sum, item) => sum + Number(item.provenance.evidence_count ?? 0), 0);
+	const staleRejected =
+		reuseTelemetry.isEnabled() && !validated.include_stale && enabled.has("observations")
+			? db.explorationObservations
+					.list({ owner, repo, include_stale: true, limit: candidateLimit, offset: 0 })
+					.filter((observation) => observation.freshness !== "valid" || observation.superseded_by).length
+			: 0;
 	const structuredData = {
 		schema: "agent-context" as const,
 		mode: "compiled" as const,
+		context_pack_id: contextPackId,
 		repo,
 		query: objective || null,
 		objective: objective || null,
@@ -217,11 +265,40 @@ export async function handleAgentContext(
 		exclusions: packed.exclusions
 	};
 
+	reuseTelemetry.recordContextPack({
+		owner,
+		repo,
+		session: validated.session_id,
+		packId: contextPackId,
+		cacheLookup: Boolean(validated.context_pack_id),
+		cacheHit: false,
+		allocation: sourceAllocation,
+		observationIds,
+		memoryIds: packed.included
+			.filter((item) => item.source === "memories" || item.source === "decisions")
+			.map((item) => item.id),
+		evidencePointers,
+		staleRejected
+	});
+	const response = createMcpResponse(structuredData, contentSummary, { contentSummary, includeJson: isJsonRequest });
+	if (validated.context_pack_id) {
+		reuseTelemetry.cachePack(contextPackId, {
+			response,
+			allocation: sourceAllocation,
+			observationIds,
+			memoryIds: packed.included
+				.filter((item) => item.source === "memories" || item.source === "decisions")
+				.map((item) => item.id),
+			evidencePointers
+		});
+	}
+	reuseTelemetry.flushIfNeeded(db);
 	logger.info("[Tool] agent-context", {
 		repo,
+		contextPackId,
 		included: packed.included.length,
 		excluded: packed.exclusions.length,
 		estimatedTokens: packed.estimatedTokens
 	});
-	return createMcpResponse(structuredData, contentSummary, { contentSummary, includeJson: isJsonRequest });
+	return response;
 }

--- a/src/mcp/tools/codebase-index-sdk.ts
+++ b/src/mcp/tools/codebase-index-sdk.ts
@@ -13,8 +13,11 @@ import type { McpResponse } from "../utils/mcp-response";
 import { SQLiteStore } from "../storage/sqlite";
 import { VectorStore } from "../types";
 import { handleCodebaseIndexRepository, handleCodebaseIndexStatus } from "./codebase-index";
+import { getCodebaseParserPool } from "../codebase-index/parser/singleton";
 import { logger } from "../utils/logger";
 import { CodebaseIndexSchema } from "./schemas/codebase-index";
+import { getRuntimeCapabilities } from "../runtime-capabilities";
+import { createMcpResponse } from "../utils/mcp-response";
 
 export { CodebaseIndexSchema };
 export type CodebaseIndexInput = z.infer<typeof CodebaseIndexSchema>;
@@ -57,6 +60,23 @@ export async function handleCodebaseIndex(
 ): Promise<McpResponse> {
 	const validated = CodebaseIndexSchema.parse(params);
 	const mode = inferMode(validated);
+	const capabilities = getRuntimeCapabilities();
+	if (!capabilities.hasLoader("indexing")) {
+		capabilities.register("indexing", () => getCodebaseParserPool().initialize());
+	}
+	if (validated.warmup) {
+		if (!capabilities.isAvailable("indexing")) {
+			return createMcpResponse(
+				capabilities.snapshot(),
+				"Index capability is unavailable in the minimal runtime profile.",
+				{ includeJson: true }
+			);
+		}
+		const status = await capabilities.warmup(["indexing"]);
+		return createMcpResponse(status, `Index capability: ${status.capabilities.indexing.state}`, {
+			includeJson: true
+		});
+	}
 
 	logger.info("[Tool] codebase-index", {
 		repo: validated.repo,
@@ -64,8 +84,15 @@ export async function handleCodebaseIndex(
 	});
 
 	switch (mode) {
-		case "index":
+		case "index": {
+			const ready = await capabilities.ensure("indexing");
+			if (!ready) {
+				return createMcpResponse(capabilities.snapshot(), "Index capability unavailable in this runtime profile.", {
+					includeJson: true
+				});
+			}
 			return handleCodebaseIndexRepository(params, db, vectors);
+		}
 		case "status":
 			return handleCodebaseIndexStatus(params, db, vectors);
 	}

--- a/src/mcp/tools/codebase-index.ts
+++ b/src/mcp/tools/codebase-index.ts
@@ -4,6 +4,7 @@ import { IndexRepoSchema, IndexStatusSchema } from "./schemas/index";
 import { SQLiteStore } from "../storage/sqlite";
 import { VectorStore } from "../types";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
+import { createMcpErrorResponse } from "../utils/mcp-error";
 import { createCodebaseIndexService } from "../codebase-index/services/indexing-service";
 import type { ParserPool } from "../codebase-index/parser/language-visitor";
 import { TreeSitterParserPool } from "../codebase-index/parser/parser-pool";
@@ -38,23 +39,19 @@ export async function handleCodebaseIndexRepository(
 	try {
 		stat = fs.statSync(resolvedPath);
 	} catch {
-		return createMcpResponse(
-			{ success: false, error: "PATH_NOT_FOUND", message: `Repository path not found: ${resolvedPath}` },
-			`Repository path not found: ${resolvedPath}`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "PATH_NOT_FOUND",
+			message: `Repository path not found: ${resolvedPath}`,
+			retryable: false
+		});
 	}
 
 	if (!stat.isDirectory()) {
-		return createMcpResponse(
-			{
-				success: false,
-				error: "NOT_A_DIRECTORY",
-				message: `Repository path is not a directory: ${resolvedPath}`
-			},
-			`Repository path is not a directory: ${resolvedPath}`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "NOT_A_DIRECTORY",
+			message: `Repository path is not a directory: ${resolvedPath}`,
+			retryable: false
+		});
 	}
 
 	const pool = getParserPool();
@@ -87,11 +84,11 @@ export async function handleCodebaseIndexRepository(
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		logger.error("[handleCodebaseIndexRepository] Index failed", { repo, error: message });
-		return createMcpResponse(
-			{ success: false, error: "INDEX_FAILED", message },
-			`Index failed for ${repo}: ${message}`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "INDEX_FAILED",
+			message: `Index failed for ${repo}`,
+			retryable: true
+		});
 	}
 }
 

--- a/src/mcp/tools/codebase-index.ts
+++ b/src/mcp/tools/codebase-index.ts
@@ -6,21 +6,10 @@ import { VectorStore } from "../types";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
 import { createMcpErrorResponse } from "../utils/mcp-error";
 import { createCodebaseIndexService } from "../codebase-index/services/indexing-service";
-import type { ParserPool } from "../codebase-index/parser/language-visitor";
-import { TreeSitterParserPool } from "../codebase-index/parser/parser-pool";
+import { getCodebaseParserPool } from "../codebase-index/parser/singleton";
 import { registerRepo } from "../codebase-index/services/file-watcher";
 import { logger } from "../utils/logger";
-
-// ── Parser pool singleton ───────────────────────────────────────────────
-
-let parserPool: ParserPool | null = null;
-
-function getParserPool(): ParserPool {
-	if (!parserPool) {
-		parserPool = new TreeSitterParserPool();
-	}
-	return parserPool;
-}
+import { getRuntimeCapabilities } from "../runtime-capabilities";
 
 // ── Handlers ────────────────────────────────────────────────────────────
 
@@ -54,7 +43,7 @@ export async function handleCodebaseIndexRepository(
 		});
 	}
 
-	const pool = getParserPool();
+	const pool = getCodebaseParserPool();
 	const service = createCodebaseIndexService(db, pool);
 
 	try {
@@ -69,6 +58,9 @@ export async function handleCodebaseIndexRepository(
 		// process (which imports this handler too) the entry is a harmless
 		// no-op — the watcher loop only runs in the MCP server process.
 		registerRepo(repo, resolvedPath);
+		const capabilities = getRuntimeCapabilities();
+		capabilities.markReady("indexing");
+		void capabilities.ensure("watcher");
 
 		const errorLines =
 			result.errors.length > 0
@@ -101,8 +93,9 @@ export async function handleCodebaseIndexStatus(
 	const repo = validated.repo.trim();
 	const repoPath = validated.repoPath?.trim();
 
-	const service = createCodebaseIndexService(db, getParserPool());
+	const service = createCodebaseIndexService(db, getCodebaseParserPool());
 	const status = await service.getIndexStatus(repo, repoPath);
+	const runtime = getRuntimeCapabilities().snapshot();
 
 	// Build key-value detail output
 	const lines: string[] = [];
@@ -136,7 +129,7 @@ export async function handleCodebaseIndexStatus(
 
 	const summary = lines.join("\n");
 
-	return createMcpResponse(status, summary, {
+	return createMcpResponse({ ...status, runtime }, summary, {
 		includeJson: true
 	});
 }

--- a/src/mcp/tools/codebase-read/architecture.ts
+++ b/src/mcp/tools/codebase-read/architecture.ts
@@ -114,9 +114,9 @@ async function handleArchitectureMode(validated: CodebaseReadInput, db: SQLiteSt
 	}
 
 	return createMcpResponse(
-		{ ...result, mode: "architecture" },
+		{ ...result, schema: "codebase-read", mode: "architecture" },
 		`Architecture: ${result.summary.totalFiles} files, ${result.summary.totalSymbols} symbols across ${Object.keys(result.summary.languageBreakdown).length} languages`,
-		{ includeJson: true, contentSummary: archSummary }
+		{ includeJson: validated.json, contentSummary: archSummary }
 	);
 }
 

--- a/src/mcp/tools/codebase-read/architecture.ts
+++ b/src/mcp/tools/codebase-read/architecture.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { CodebaseReadInput } from "../schemas/codebase-read";
 import { SQLiteStore } from "../../storage/sqlite";
 import { createMcpResponse, type McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import {
 	buildArchitectureFromData,
 	renderDirTree,
@@ -38,11 +39,11 @@ function resolveOptionalRepoPath(raw: string | undefined): string | null {
 async function handleArchitectureMode(validated: CodebaseReadInput, db: SQLiteStore): Promise<McpResponse> {
 	const repo = validated.repo;
 	if (!repo) {
-		return createMcpResponse(
-			{ error: "Mode 'architecture' requires a concrete 'repo'", code: "REPO_REQUIRED" },
-			"Mode 'architecture' requires a concrete 'repo'.",
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_REQUIRED",
+			message: "Mode 'architecture' requires a concrete 'repo'.",
+			retryable: false
+		});
 	}
 	const depth = validated.depth ?? 2;
 

--- a/src/mcp/tools/codebase-read/code.ts
+++ b/src/mcp/tools/codebase-read/code.ts
@@ -81,6 +81,7 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 	if (content.length === 0) {
 		return createMcpResponse(
 			{
+				schema: "codebase-read",
 				mode: "code",
 				content: "",
 				regex: validated.regex,
@@ -94,7 +95,7 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 				limit: validated.limit ?? CODE_SEARCH_DEFAULT_LIMIT
 			},
 			"Empty content query — nothing searched (pass `content` to grep indexed file contents)",
-			{ includeJson: true }
+			{ includeJson: validated.json }
 		);
 	}
 
@@ -175,6 +176,7 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 
 		return createMcpResponse(
 			{
+				schema: "codebase-read",
 				mode: "code",
 				content,
 				regex: validated.regex,
@@ -189,7 +191,7 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 				limit
 			},
 			`Found ${result.total} content matches for "${content}" (showing ${result.matches.length}) across ${result.filesScanned} indexed files.`,
-			{ includeJson: true, contentSummary }
+			{ includeJson: validated.json, contentSummary }
 		);
 	} catch (err) {
 		if (err instanceof InvalidCodeSearchRegexError) {

--- a/src/mcp/tools/codebase-read/code.ts
+++ b/src/mcp/tools/codebase-read/code.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { CodebaseReadInput } from "../schemas/codebase-read";
 import { SQLiteStore } from "../../storage/sqlite";
 import { createMcpResponse, type McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import {
 	searchCodeInRepo,
 	InvalidCodeSearchRegexError,
@@ -99,23 +100,21 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 
 	const repo = validated.repo;
 	if (!repo) {
-		return createMcpResponse(
-			{ error: "Mode 'code' requires a concrete 'repo'", code: "REPO_REQUIRED" },
-			"Mode 'code' requires a concrete 'repo'.",
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_REQUIRED",
+			message: "Mode 'code' requires a concrete 'repo'.",
+			retryable: false
+		});
 	}
 
 	const repoPath = validated.repoPath?.trim();
 	if (!repoPath) {
-		return createMcpResponse(
-			{
-				error: "Code search requires `repoPath` — the absolute path of the indexed repo on disk",
-				code: "REPO_PATH_REQUIRED"
-			},
-			"Code search requires `repoPath`: pass the same absolute path used with index_repository, or run index_repository first.",
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_PATH_REQUIRED",
+			message:
+				"Code search requires `repoPath`: pass the same absolute path used with index_repository, or run index_repository first.",
+			retryable: false
+		});
 	}
 
 	const resolvedPath = path.resolve(repoPath);
@@ -123,24 +122,18 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 	try {
 		stat = fs.statSync(resolvedPath);
 	} catch {
-		return createMcpResponse(
-			{
-				error: `Repository path not found: ${resolvedPath}. Re-run index_repository or pass the correct repoPath.`,
-				code: "REPO_PATH_NOT_FOUND"
-			},
-			`Repository path not found: ${resolvedPath}`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_PATH_NOT_FOUND",
+			message: `Repository path not found: ${resolvedPath}. Re-run index_repository or pass the correct repoPath.`,
+			retryable: false
+		});
 	}
 	if (!stat.isDirectory()) {
-		return createMcpResponse(
-			{
-				error: `Repository path is not a directory: ${resolvedPath}`,
-				code: "REPO_PATH_NOT_FOUND"
-			},
-			`Repository path is not a directory: ${resolvedPath}`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "NOT_A_DIRECTORY",
+			message: `Repository path is not a directory: ${resolvedPath}`,
+			retryable: false
+		});
 	}
 
 	const limit = validated.limit ?? CODE_SEARCH_DEFAULT_LIMIT;
@@ -158,14 +151,11 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 		// A repo with zero indexed files is not resolvable as a grep target —
 		// surface guidance instead of a misleading "0 matches".
 		if (result.indexedFiles === 0) {
-			return createMcpResponse(
-				{
-					error: `Repo "${repo}" has no indexed files. Run index_repository first.`,
-					code: "REPO_NOT_INDEXED"
-				},
-				`Repo "${repo}" has no indexed files. Run index_repository first.`,
-				{ includeJson: true }
-			);
+			return createMcpErrorResponse({
+				code: "REPO_NOT_INDEXED",
+				message: `Repo "${repo}" has no indexed files. Run index_repository first.`,
+				retryable: false
+			});
 		}
 
 		// Every in-scope indexed file failed to read ⇒ the repoPath is almost
@@ -173,14 +163,12 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 		// than "0 matches". (A language filter matching no files yields
 		// fileCount 0, which falls through to the normal empty response.)
 		if (result.fileCount > 0 && result.filesScanned === 0) {
-			return createMcpResponse(
-				{
-					error: `None of the ${result.fileCount} indexed files could be read at ${resolvedPath}. Re-run index_repository or pass the correct repoPath.`,
-					code: "REPO_FILES_MISSING"
-				},
-				`None of the ${result.fileCount} indexed files could be read at ${resolvedPath}.`,
-				{ includeJson: true }
-			);
+			return createMcpErrorResponse({
+				code: "REPO_FILES_MISSING",
+				message: `None of the ${result.fileCount} indexed files could be read. Re-run index_repository or pass the correct repoPath.`,
+				retryable: false,
+				details: { fileCount: result.fileCount }
+			});
 		}
 
 		const contentSummary = formatCodeMatchesGrouped(result.matches, result.total, content);
@@ -205,13 +193,15 @@ async function handleCodeSearchMode(validated: CodebaseReadInput, db: SQLiteStor
 		);
 	} catch (err) {
 		if (err instanceof InvalidCodeSearchRegexError) {
-			return createMcpResponse({ error: err.message, code: "INVALID_REGEX" }, err.message, {
-				includeJson: true
-			});
+			return createMcpErrorResponse({ code: "INVALID_REGEX", message: err.message, retryable: false });
 		}
 		const message = err instanceof Error ? err.message : String(err);
 		logger.error("[handleCodebaseRead:code] Unexpected error", { repo, content, error: message });
-		return createMcpResponse({ error: message, code: "CODE_SEARCH_FAILED" }, message, { includeJson: true });
+		return createMcpErrorResponse({
+			code: "CODE_SEARCH_FAILED",
+			message: "Code search failed",
+			retryable: true
+		});
 	}
 }
 

--- a/src/mcp/tools/codebase-read/file.ts
+++ b/src/mcp/tools/codebase-read/file.ts
@@ -241,6 +241,7 @@ async function handleFileMode(validated: CodebaseReadInput, db: SQLiteStore): Pr
 
 	return createMcpResponse(
 		{
+			schema: "codebase-read",
 			mode: "file",
 			file: {
 				path: file.file_path,
@@ -254,7 +255,7 @@ async function handleFileMode(validated: CodebaseReadInput, db: SQLiteStore): Pr
 			total: symbols.length
 		},
 		`Found ${symbols.length} symbols in ${filePath}`,
-		{ includeJson: true, contentSummary }
+		{ includeJson: validated.json, contentSummary }
 	);
 }
 
@@ -383,6 +384,7 @@ async function handleFileRangeMode(
 
 	return createMcpResponse(
 		{
+			schema: "codebase-read",
 			mode: "file",
 			file: {
 				path: file.file_path,
@@ -411,7 +413,7 @@ async function handleFileRangeMode(
 				? `, ${contextPack.items.length} symbols packed (~${contextPack.estimatedTokens} est. tokens${contextPack.capped ? ", budget reached" : ""})`
 				: ""
 		}`,
-		{ includeJson: true, contentSummary }
+		{ includeJson: validated.json, contentSummary }
 	);
 }
 

--- a/src/mcp/tools/codebase-read/file.ts
+++ b/src/mcp/tools/codebase-read/file.ts
@@ -1,6 +1,7 @@
 import type { CodebaseReadInput } from "../schemas/codebase-read";
 import { SQLiteStore } from "../../storage/sqlite";
 import { createMcpResponse, type McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { docSuffix } from "../../utils/doc-comment-format";
 import type { CodebaseSymbol, CodebaseReference, RelatedTypeEdge, PackedContextResult } from "../../types";
 import type { TraceReference } from "../../codebase-index/services/trace-service";
@@ -156,21 +157,22 @@ function mergeContextPacks(packs: PackedContextResult[], budget: number): Packed
 async function handleFileMode(validated: CodebaseReadInput, db: SQLiteStore): Promise<McpResponse> {
 	const repo = validated.repo;
 	if (!repo) {
-		return createMcpResponse(
-			{ error: "Mode 'file' requires a concrete 'repo'", code: "REPO_REQUIRED" },
-			"Mode 'file' requires a concrete 'repo'.",
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_REQUIRED",
+			message: "Mode 'file' requires a concrete 'repo'.",
+			retryable: false
+		});
 	}
 	const filePath = validated.filePath!.trim();
 
 	const file = db.codebaseFiles.getFile(repo, filePath);
 	if (!file) {
-		return createMcpResponse(
-			{ error: "File not indexed. Run index_repository first.", code: "FILE_NOT_INDEXED" },
-			`File '${filePath}' not found in index`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "FILE_NOT_INDEXED",
+			message: "File not indexed. Run index_repository first.",
+			retryable: false,
+			details: { filePath }
+		});
 	}
 
 	const allFileSymbols = db.codebaseSymbols.getSymbolsByFile(repo, filePath);
@@ -181,35 +183,30 @@ async function handleFileMode(validated: CodebaseReadInput, db: SQLiteStore): Pr
 	const hasEnd = endLine != null;
 
 	if (hasStart !== hasEnd) {
-		return createMcpResponse(
-			{
-				error: "startLine and endLine must be provided together for range-aware FILE mode",
-				code: "RANGE_INCOMPLETE"
-			},
-			"startLine and endLine must be provided together for range-aware FILE mode.",
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "RANGE_INCOMPLETE",
+			message: "startLine and endLine must be provided together for range-aware FILE mode.",
+			retryable: false
+		});
 	}
 
 	if (hasStart && hasEnd) {
 		const s = startLine as number;
 		const e = endLine as number;
 		if (s > e) {
-			return createMcpResponse(
-				{ error: `endLine (${e}) must be >= startLine (${s})`, code: "RANGE_OUT_OF_ORDER" },
-				`endLine (${e}) must be >= startLine (${s}).`,
-				{ includeJson: true }
-			);
+			return createMcpErrorResponse({
+				code: "RANGE_OUT_OF_ORDER",
+				message: `endLine (${e}) must be >= startLine (${s}).`,
+				retryable: false
+			});
 		}
 		if (file.lines != null && e > file.lines) {
-			return createMcpResponse(
-				{
-					error: `endLine (${e}) exceeds file length (${file.lines} lines)`,
-					code: "RANGE_OUT_OF_BOUNDS"
-				},
-				`endLine (${e}) exceeds file length (${file.lines} lines).`,
-				{ includeJson: true }
-			);
+			return createMcpErrorResponse({
+				code: "RANGE_OUT_OF_BOUNDS",
+				message: `endLine (${e}) exceeds file length (${file.lines} lines).`,
+				retryable: false,
+				details: { startLine: s, endLine: e, fileLines: file.lines }
+			});
 		}
 		// Range is valid — run the enriched FILE mode.
 		return handleFileRangeMode(validated, db, repo, filePath, file, allFileSymbols, { startLine: s, endLine: e });

--- a/src/mcp/tools/codebase-read/scope.ts
+++ b/src/mcp/tools/codebase-read/scope.ts
@@ -1,5 +1,6 @@
 import type { CodebaseReadInput, CodebaseReadMode } from "../schemas/codebase-read";
-import { createMcpResponse, type McpResponse } from "../../utils/mcp-response";
+import type { McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 
 // ── SCOPE GUARD ─────────────────────────────────────────────────────────
 
@@ -18,24 +19,22 @@ export function requireRepoScope(validated: CodebaseReadInput, mode: CodebaseRea
 
 	if (mode === "search") {
 		if (!validated.repo && !hasRepos) {
-			return createMcpResponse(
-				{
-					error: "Search requires `repo` or `repos`",
-					code: "REPO_REQUIRED"
-				},
-				"Search requires `repo` or `repos` to scope the query (cross-tenant guard — codebase_symbols has no owner column).",
-				{ includeJson: true }
-			);
+			return createMcpErrorResponse({
+				code: "REPO_REQUIRED",
+				message:
+					"Search requires `repo` or `repos` to scope the query (cross-tenant guard — codebase_symbols has no owner column).",
+				retryable: false
+			});
 		}
 		return null;
 	}
 
 	if (!validated.repo) {
-		return createMcpResponse(
-			{ error: `Mode '${mode}' requires a concrete 'repo'`, code: "REPO_REQUIRED" },
-			`Mode '${mode}' requires a concrete 'repo'.`,
-			{ includeJson: true }
-		);
+		return createMcpErrorResponse({
+			code: "REPO_REQUIRED",
+			message: `Mode '${mode}' requires a concrete 'repo'.`,
+			retryable: false
+		});
 	}
 	return null;
 }

--- a/src/mcp/tools/codebase-read/search.ts
+++ b/src/mcp/tools/codebase-read/search.ts
@@ -182,9 +182,9 @@ async function handleSearchMode(
 	const rawQuery = (validated.query ?? "").trim();
 	if (rawQuery.length < 2) {
 		return createMcpResponse(
-			{ symbols: [], total: 0, hasMore: false, mode: "search" },
+			{ schema: "codebase-read", symbols: [], total: 0, hasMore: false, mode: "search" },
 			"Search query too short (minimum 2 characters)",
-			{ includeJson: true }
+			{ includeJson: validated.json }
 		);
 	}
 	// Defensive inline tag extraction (TASK-443): pull `key:value` filters out of
@@ -342,6 +342,7 @@ async function handleSearchMode(
 
 	return createMcpResponse(
 		{
+			schema: "codebase-read",
 			symbols: results,
 			related,
 			total,
@@ -354,7 +355,7 @@ async function handleSearchMode(
 			scope
 		},
 		`Found ${total} matching symbols for "${query}" (showing ${results.length}).`,
-		{ includeJson: true, contentSummary }
+		{ includeJson: validated.json, contentSummary }
 	);
 }
 

--- a/src/mcp/tools/codebase-read/trace.ts
+++ b/src/mcp/tools/codebase-read/trace.ts
@@ -255,6 +255,7 @@ async function handleTraceMode(validated: CodebaseReadInput, db: SQLiteStore): P
 			return createMcpResponse(
 				{
 					...result,
+					schema: "codebase-read",
 					mode: "trace",
 					originalName: traceName !== name ? name : undefined,
 					relatedTypes: relatedTypes ? relatedTypes.edges : undefined,
@@ -279,7 +280,7 @@ async function handleTraceMode(validated: CodebaseReadInput, db: SQLiteStore): P
 					(contextPack
 						? `, ${contextPack.items.length} symbols packed (~${contextPack.estimatedTokens} est. tokens, ${contextPack.capped ? "budget reached" : "within budget"})`
 						: ""),
-				{ includeJson: true, contentSummary }
+				{ includeJson: validated.json, contentSummary }
 			);
 		} catch (err) {
 			// Re-throw ambiguous errors — they should propagate, not fall through

--- a/src/mcp/tools/codebase-read/trace.ts
+++ b/src/mcp/tools/codebase-read/trace.ts
@@ -2,6 +2,7 @@ import type { CodebaseReadInput } from "../schemas/codebase-read";
 import { SQLiteStore } from "../../storage/sqlite";
 import type { CodebaseSymbol, CodebaseReference, RelatedTypeEdge, PackedContextResult } from "../../types";
 import { createMcpResponse, type McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import {
 	traceSymbol,
 	AmbiguousSymbolError,
@@ -331,10 +332,11 @@ async function handleTraceMode(validated: CodebaseReadInput, db: SQLiteStore): P
 		}
 	} catch (err) {
 		if (err instanceof AmbiguousSymbolError) {
-			return createMcpResponse(
-				{
-					error: err.message,
-					code: "AMBIGUOUS_SYMBOL",
+			return createMcpErrorResponse({
+				code: "AMBIGUOUS_SYMBOL",
+				message: err.message,
+				retryable: false,
+				details: {
 					disambiguation: err.disambiguation.map((s) => ({
 						name: s.name,
 						kind: s.kind,
@@ -342,24 +344,20 @@ async function handleTraceMode(validated: CodebaseReadInput, db: SQLiteStore): P
 						line: s.start_line,
 						exported: s.exported
 					}))
-				},
-				err.message,
-				{ includeJson: true }
-			);
+				}
+			});
 		}
 		const message = err instanceof Error ? err.message : String(err);
 		logger.error("[handleCodebaseRead:trace] Unexpected error", { name, repo, error: message });
-		return createMcpResponse({ error: message, code: "TRACE_FAILED" }, message, {
-			includeJson: true
-		});
+		return createMcpErrorResponse({ code: "TRACE_FAILED", message: "Symbol trace failed", retryable: true });
 	}
 
 	// All variants failed — return SymbolNotFoundError for the original name
-	return createMcpResponse(
-		{ error: `Symbol "${name}" not found`, code: "SYMBOL_NOT_FOUND" },
-		`Symbol "${name}" not found`,
-		{ includeJson: true }
-	);
+	return createMcpErrorResponse({
+		code: "SYMBOL_NOT_FOUND",
+		message: `Symbol "${name}" not found`,
+		retryable: false
+	});
 }
 
 export { handleTraceMode };

--- a/src/mcp/tools/exploration-observation.read.ts
+++ b/src/mcp/tools/exploration-observation.read.ts
@@ -1,0 +1,66 @@
+import { SQLiteStore } from "../storage/sqlite";
+import { buildTableResult, createMcpResponse, type McpResponse, withEnvelope } from "../utils/mcp-response";
+import { ExplorationObservationReadSchema } from "./schemas";
+
+export async function handleExplorationObservationRead(
+	args: Record<string, unknown>,
+	storage: SQLiteStore
+): Promise<McpResponse> {
+	const validated = ExplorationObservationReadSchema.parse(args);
+	if (validated.id) {
+		const observation = storage.explorationObservations.getById(
+			validated.owner,
+			validated.repo,
+			validated.id,
+			validated.hydrate_evidence
+		);
+		if (!observation) throw new Error(`Exploration observation not found: ${validated.id}`);
+		const summary = `[${observation.id.slice(0, 8)}] ${observation.subject}: ${observation.fact}`;
+		return createMcpResponse(withEnvelope("observation-read", "detail", { observation }), summary, {
+			contentSummary: summary,
+			includeJson: validated.json
+		});
+	}
+
+	const observations = storage.explorationObservations.list(validated, validated.hydrate_evidence);
+	const columns = [
+		"id",
+		"subject",
+		"fact",
+		"confidence",
+		"freshness",
+		"task_id",
+		"agent",
+		"evidence_count",
+		"updated_at",
+		...(validated.hydrate_evidence ? ["evidence"] : [])
+	];
+	const rows = observations.map((item) => [
+		item.id,
+		item.subject,
+		item.fact.length > 320 ? `${item.fact.slice(0, 320)}...` : item.fact,
+		item.confidence,
+		item.freshness,
+		item.task_id,
+		item.agent,
+		item.evidence_count,
+		item.updated_at,
+		...(validated.hydrate_evidence ? [item.evidence ?? []] : [])
+	]);
+	const data = buildTableResult(columns, rows, {
+		schema: "observation-read",
+		mode: "list",
+		key: "observations",
+		count: rows.length,
+		offset: validated.offset
+	});
+	const summary = observations.length
+		? observations
+				.map((item) => {
+					const fact = item.fact.length > 240 ? `${item.fact.slice(0, 240)}...` : item.fact;
+					return `- [${item.id.slice(0, 8)}] (${item.confidence.toFixed(2)}) ${item.subject}: ${fact}`;
+				})
+				.join("\n")
+		: "No exploration observations found.";
+	return createMcpResponse(data, summary, { contentSummary: summary, includeJson: validated.json });
+}

--- a/src/mcp/tools/exploration-observation.write.ts
+++ b/src/mcp/tools/exploration-observation.write.ts
@@ -1,0 +1,38 @@
+import { SQLiteStore } from "../storage/sqlite";
+import type { ExplorationObservationInput } from "../types";
+import { createMcpResponse, type McpResponse, withEnvelope } from "../utils/mcp-response";
+import { ExplorationObservationWriteSchema } from "./schemas";
+
+export async function handleExplorationObservationWrite(
+	args: Record<string, unknown>,
+	storage: SQLiteStore
+): Promise<McpResponse> {
+	const validated = ExplorationObservationWriteSchema.parse(args);
+	const inputs: ExplorationObservationInput[] = validated.observations ?? [
+		{
+			subject: validated.subject!,
+			fact: validated.fact!,
+			confidence: validated.confidence!,
+			evidence: validated.evidence!,
+			task_id: validated.task_id,
+			agent: validated.agent
+		}
+	];
+	const results = storage.explorationObservations.upsertMany(validated.owner, validated.repo, inputs, validated.id);
+	const created = results.filter((result) => result.created).length;
+	const deduplicated = results.length - created;
+	const data = withEnvelope("observation-write", validated.observations ? "bulk" : validated.id ? "update" : "create", {
+		success: true,
+		created,
+		deduplicated,
+		results: results.map(({ observation, created: wasCreated }) => ({
+			id: observation.id,
+			subject: observation.subject,
+			confidence: observation.confidence,
+			evidence_count: observation.evidence_count,
+			created: wasCreated
+		}))
+	});
+	const summary = `Published ${results.length} observation${results.length === 1 ? "" : "s"}: ${created} created, ${deduplicated} deduplicated.`;
+	return createMcpResponse(data, summary, { contentSummary: summary, includeJson: validated.json });
+}

--- a/src/mcp/tools/exploration-observation.write.ts
+++ b/src/mcp/tools/exploration-observation.write.ts
@@ -8,6 +8,22 @@ export async function handleExplorationObservationWrite(
 	storage: SQLiteStore
 ): Promise<McpResponse> {
 	const validated = ExplorationObservationWriteSchema.parse(args);
+	if (validated.refresh_ids) {
+		const observations = storage.explorationObservations.refreshByIds(
+			validated.owner,
+			validated.repo,
+			validated.refresh_ids
+		);
+		const summary = `Refreshed ${observations.length} observation fingerprint${observations.length === 1 ? "" : "s"}.`;
+		return createMcpResponse(
+			withEnvelope("observation-write", "refresh", { observations, count: observations.length }),
+			summary,
+			{
+				contentSummary: summary,
+				includeJson: validated.json
+			}
+		);
+	}
 	const inputs: ExplorationObservationInput[] = validated.observations ?? [
 		{
 			subject: validated.subject!,
@@ -15,7 +31,8 @@ export async function handleExplorationObservationWrite(
 			confidence: validated.confidence!,
 			evidence: validated.evidence!,
 			task_id: validated.task_id,
-			agent: validated.agent
+			agent: validated.agent,
+			supersedes_id: validated.supersedes_id
 		}
 	];
 	const results = storage.explorationObservations.upsertMany(validated.owner, validated.repo, inputs, validated.id);

--- a/src/mcp/tools/handoff.read.ts
+++ b/src/mcp/tools/handoff.read.ts
@@ -1,5 +1,5 @@
 import { SQLiteStore } from "../storage/sqlite";
-import { buildTableResult, createMcpResponse, McpResponse } from "../utils/mcp-response";
+import { buildTableResult, createMcpResponse, McpResponse, withEnvelope } from "../utils/mcp-response";
 import { inferReadMode } from "../utils/auto-infer";
 import { HandoffReadSchema } from "./schemas/index";
 
@@ -93,7 +93,7 @@ function coreDetail(id: string, json: boolean, storage: SQLiteStore): McpRespons
 	const excerpt = handoff.summary.length > 60 ? handoff.summary.slice(0, 60) + "..." : handoff.summary;
 	const contentSummary = `Handoff [${id.slice(0, 8)}] "${excerpt}" — ${handoff.from_agent}→${handoff.to_agent || "unassigned"} (${handoff.status})`;
 
-	return createMcpResponse(handoff, contentSummary, {
+	return createMcpResponse(withEnvelope("handoff-read", "detail", handoff), contentSummary, {
 		contentSummary,
 		includeJson: json
 	});
@@ -135,6 +135,7 @@ function coreListClaims(
 
 	const structuredData = buildTableResult(COLUMNS, rows, {
 		schema: "claim-list",
+		mode: "claims",
 		key: "claims",
 		count: rows.length,
 		offset
@@ -159,6 +160,7 @@ function coreListHandoffs(
 	toAgent: string | undefined,
 	limit: number,
 	offset: number,
+	mode: "list" | "search",
 	json: boolean,
 	storage: SQLiteStore
 ): McpResponse {
@@ -201,6 +203,7 @@ function coreListHandoffs(
 
 	const structuredData = buildTableResult(COLUMNS, rows, {
 		schema: "handoff-read",
+		mode,
 		key: "handoffs",
 		count: rows.length,
 		offset
@@ -276,10 +279,10 @@ export async function handleHandoffRead(args: unknown, storage: SQLiteStore): Pr
 	// ── 3. query present → SEARCH handoffs ───────────────────────
 	if (mode === "search") {
 		requireOwnerRepo(owner, repo);
-		return coreListHandoffs(owner, repo, status, from_agent, to_agent, limit, offset, json, storage);
+		return coreListHandoffs(owner, repo, status, from_agent, to_agent, limit, offset, "search", json, storage);
 	}
 
 	// ── 4. Fallback → LIST HANDOFFS (no filters) ─────────────────
 	requireOwnerRepo(owner, repo);
-	return coreListHandoffs(owner, repo, status, from_agent, to_agent, limit, offset, json, storage);
+	return coreListHandoffs(owner, repo, status, from_agent, to_agent, limit, offset, "list", json, storage);
 }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -66,6 +66,7 @@ import { toErrorResponse } from "../utils/mcp-error";
 import { logToolAction } from "../utils/action-log";
 import { collectAffectedResourceUris, WRITE_TOOLS } from "../utils/tool-plumbing";
 import { getRuntimeCapabilities, isSemanticToolDemand } from "../runtime-capabilities";
+import { reuseTelemetry } from "../utils/reuse-telemetry";
 
 // ── Tool definitions ────────────────────────────────────────────────────
 import { TOOL_DEFINITIONS } from "./tool-definitions";
@@ -164,7 +165,8 @@ export function buildExecutors(
 		"task-read": (args, db, vectors, _extra) => handleTaskRead(args, db, vectors),
 		"task-delete": (args, db, _vectors, _extra) => handleTaskDelete(args, db),
 
-		"agent-context": (args, db, vectors, _extra) => handleAgentContext(args, db, vectors),
+		"agent-context": (args, db, vectors, _extra) =>
+			handleAgentContext(session.sessionId ? { ...args, session_id: session.sessionId } : args, db, vectors),
 		"observation-write": (args, db, _vectors, _extra) => handleExplorationObservationWrite(args, db),
 		"observation-read": (args, db, _vectors, _extra) => handleExplorationObservationRead(args, db),
 		// Codebase index tools — only 2 canonical names
@@ -314,6 +316,15 @@ export function registerAllTools(
 				// lives in logToolAction (utils/action-log.ts) over
 				// ACTION_LOG_TOOLS (utils/tool-plumbing.ts), shared with router.ts.
 				logToolAction(store, toolName, normalizedArgs, result);
+				reuseTelemetry.recordTool({
+					owner: String(normalizedArgs.owner ?? ""),
+					repo: String(normalizedArgs.repo ?? "unknown"),
+					session: [session.sessionId, normalizedArgs.task_code ?? normalizedArgs.task_id ?? ""].join(":"),
+					toolName,
+					args: normalizedArgs,
+					result
+				});
+				reuseTelemetry.flushIfNeeded(store);
 
 				// Resource mutation notifications
 				const affectedUris = collectAffectedResourceUris(toolName, normalizedArgs, result);

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -272,16 +272,26 @@ export function registerAllTools(
 					// Instrumented on the error path too: a fast-failing tool
 					// must still show up in per-tool latency stats.
 					const errDurationMs = performance.now() - toolStartMs;
-					metrics.recordTool(toolName, errDurationMs);
+					metrics.recordTool(toolName, errDurationMs, "error");
 					logger.error(`[Tool] ${toolName} failed`, {
 						error: String(err),
 						durationMs: Math.round(errDurationMs * 100) / 100
 					});
-					return toCallToolResult(toErrorResponse(err));
+					const errorResponse = toErrorResponse(err);
+					logToolAction(store, toolName, normalizedArgs, errorResponse);
+					return toCallToolResult(errorResponse);
 				}
 
 				const durationMs = performance.now() - toolStartMs;
-				metrics.recordTool(toolName, durationMs);
+				const structured = result.structuredContent as { code?: unknown; degraded?: unknown } | undefined;
+				const outcome = result.isError
+					? structured?.code === "PARTIAL_FAILURE"
+						? "partial"
+						: "error"
+					: structured?.degraded === true
+						? "degraded"
+						: "success";
+				metrics.recordTool(toolName, durationMs, outcome);
 				logger.info(`[Tool] ${toolName} result`, {
 					repo: (normalizedArgs?.repo as string) || "unknown",
 					durationMs: Math.round(durationMs * 100) / 100

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -65,6 +65,7 @@ import { McpResponse } from "../utils/mcp-response";
 import { toErrorResponse } from "../utils/mcp-error";
 import { logToolAction } from "../utils/action-log";
 import { collectAffectedResourceUris, WRITE_TOOLS } from "../utils/tool-plumbing";
+import { getRuntimeCapabilities, isSemanticToolDemand } from "../runtime-capabilities";
 
 // ── Tool definitions ────────────────────────────────────────────────────
 import { TOOL_DEFINITIONS } from "./tool-definitions";
@@ -237,6 +238,13 @@ export function registerAllTools(
 							: undefined,
 					signal: extra?.mcpReq?.signal
 				};
+
+				// Trigger lazy semantic startup only for calls that can use it. The
+				// capability-aware vector store still degrades to lexical results if
+				// the profile disables semantic search or initialization fails.
+				if (isSemanticToolDemand(toolName, normalizedArgs)) {
+					void getRuntimeCapabilities().ensure("semantic");
+				}
 
 				// Execute tool logic under write lock if needed.
 				//

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -59,6 +59,8 @@ import { handleTaskRead } from "./task-read";
 import { handleAgentContext } from "./agent-context";
 import { handleCodebaseIndex } from "./codebase-index-sdk";
 import { handleCodebaseRead } from "./codebase.read";
+import { handleExplorationObservationWrite } from "./exploration-observation.write";
+import { handleExplorationObservationRead } from "./exploration-observation.read";
 import { McpResponse } from "../utils/mcp-response";
 import { toErrorResponse } from "../utils/mcp-error";
 import { logToolAction } from "../utils/action-log";
@@ -162,6 +164,8 @@ export function buildExecutors(
 		"task-delete": (args, db, _vectors, _extra) => handleTaskDelete(args, db),
 
 		"agent-context": (args, db, vectors, _extra) => handleAgentContext(args, db, vectors),
+		"observation-write": (args, db, _vectors, _extra) => handleExplorationObservationWrite(args, db),
+		"observation-read": (args, db, _vectors, _extra) => handleExplorationObservationRead(args, db),
 		// Codebase index tools — only 2 canonical names
 		"codebase-index": (args, db, _vectors, _extra) => handleCodebaseIndex(args, db, _vectors),
 		"codebase-read": (args, db, _vectors, _extra) => handleCodebaseRead(args, db, _vectors)

--- a/src/mcp/tools/kg-archivist/query.ts
+++ b/src/mcp/tools/kg-archivist/query.ts
@@ -53,7 +53,7 @@ export function kgQuery(db: SQLiteStore, repo: string, entityNames: string[], so
 		const capped = uniqueNames.slice(0, KG_MAX_CONTEXT_ENTITIES);
 
 		const entities = db.knowledgeGraph
-			.getEntitiesFor(capped)
+			.getEntitiesFor(capped, repo)
 			.map((e) => ({ name: e.name, type: e.type, source_domain: sourceDomain }));
 
 		const relations = db.knowledgeGraph.getRelationsFor(capped, repo);

--- a/src/mcp/tools/memory-read/detail.ts
+++ b/src/mcp/tools/memory-read/detail.ts
@@ -12,7 +12,7 @@
 
 import { MemoryEntry } from "../../types";
 import { SQLiteStore } from "../../storage/sqlite";
-import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpResponse, McpResponse, withEnvelope } from "../../utils/mcp-response";
 import { UUID_REGEX } from "../../utils/uuid";
 import { isMemoryAcknowledged } from "../../utils/memory-utils";
 import { fetchKgContext, fetchAggregatedKgContext } from "../kg-archivist/query";
@@ -72,7 +72,7 @@ export async function handleDetailMode(validated: MemoryReadInput, db: SQLiteSto
 			: null;
 		const data: Record<string, unknown> = { memories: memories.map(withAcknowledged) };
 		if (kgContext) data.kg = kgContext;
-		return createMcpResponse(data, contentSummary, {
+		return createMcpResponse(withEnvelope("memory-read", "detail", data), contentSummary, {
 			contentSummary,
 			includeJson: validated.json
 		});
@@ -92,7 +92,7 @@ export async function handleDetailMode(validated: MemoryReadInput, db: SQLiteSto
 			: null;
 		const data: Record<string, unknown> = { memories: memories.map(withAcknowledged) };
 		if (kgContext) data.kg = kgContext;
-		return createMcpResponse(data, contentSummary, {
+		return createMcpResponse(withEnvelope("memory-read", "detail", data), contentSummary, {
 			contentSummary,
 			includeJson: validated.json
 		});
@@ -120,7 +120,7 @@ export async function handleDetailMode(validated: MemoryReadInput, db: SQLiteSto
 	const data: Record<string, unknown> = { memory: withAcknowledged(memory) };
 	if (kgContext) data.kg = kgContext;
 
-	return createMcpResponse(data, content, {
+	return createMcpResponse(withEnvelope("memory-read", "detail", data), content, {
 		contentSummary: content,
 		includeJson: validated.json
 	});

--- a/src/mcp/tools/memory-read/recap.ts
+++ b/src/mcp/tools/memory-read/recap.ts
@@ -93,6 +93,8 @@ export async function handleRecapMode(params: MemoryReadInput, db: SQLiteStore):
 	}
 
 	const structuredData: Record<string, unknown> = {
+		schema: "memory-read",
+		mode: "recap",
 		stats: { byType },
 		top: {
 			columns: [...MEMORY_COLUMNS],

--- a/src/mcp/tools/memory-read/search.ts
+++ b/src/mcp/tools/memory-read/search.ts
@@ -332,6 +332,8 @@ export async function handleSearchMode(
 	}
 
 	const structuredData = buildTableResult(MEMORY_COLUMNS, rows, {
+		schema: "memory-read",
+		mode: "search",
 		count: paginatedResults.length,
 		total,
 		offset: params.offset,

--- a/src/mcp/tools/memory-write/bulk.ts
+++ b/src/mcp/tools/memory-write/bulk.ts
@@ -3,6 +3,7 @@ import { SQLiteStore } from "../../storage/sqlite";
 import { VectorStore, MemoryEntry, MEMORY_STATUS_ARCHIVED } from "../../types";
 import { logger } from "../../utils/logger";
 import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { enqueueMemory } from "../../embedding-queue";
 import { resolveEntityRef } from "../../utils/entity-ref";
 import { hasMetadataLikeTitle, resolveMemorySupersedes } from "../../utils/memory-utils";
@@ -190,8 +191,7 @@ export async function handleBulk(
 						db,
 						vectors,
 						isTaskArchive,
-						resolvedS,
-						json
+						resolvedS
 					);
 					if (conflict) {
 						throw new Error((conflictResponse!.content?.[0] as { text?: string })?.text ?? "Conflict detected");
@@ -261,18 +261,24 @@ export async function handleBulk(
 		opParts.push(`${opLabel}: ${sample}`);
 	}
 
-	return createMcpResponse(
-		{
-			success: errorCount === 0,
-			total: items.length,
-			processed: successCount,
-			results,
-			...(errorCount > 0 ? { errors } : {})
-		},
-		`Processed ${successCount}/${items.length} — ${opParts.join("; ")}${errorCount > 0 ? `; ${errorCount} failed` : ""}.`,
-		{
-			structuredContentPathHint: "results",
-			includeJson: json
-		}
-	);
+	const data = {
+		success: errorCount === 0,
+		total: items.length,
+		processed: successCount,
+		results,
+		...(errorCount > 0 ? { errors } : {})
+	};
+	const summary = `Processed ${successCount}/${items.length} — ${opParts.join("; ")}${errorCount > 0 ? `; ${errorCount} failed` : ""}.`;
+	if (errorCount > 0) {
+		return createMcpErrorResponse({
+			code: successCount > 0 ? "PARTIAL_FAILURE" : "BULK_OPERATION_FAILED",
+			message: summary,
+			retryable: false,
+			data
+		});
+	}
+	return createMcpResponse(data, summary, {
+		structuredContentPathHint: "results",
+		includeJson: json
+	});
 }

--- a/src/mcp/tools/memory-write/create.ts
+++ b/src/mcp/tools/memory-write/create.ts
@@ -44,8 +44,7 @@ export async function handleCreate(
 		db,
 		vectors,
 		isTaskArchive,
-		resolvedSupersedes,
-		json
+		resolvedSupersedes
 	);
 	if (conflict) {
 		return conflictResponse!;

--- a/src/mcp/tools/memory-write/helpers.ts
+++ b/src/mcp/tools/memory-write/helpers.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { SQLiteStore } from "../../storage/sqlite";
 import { VectorStore, MemoryEntry, MEMORY_STATUS_ACTIVE } from "../../types";
-import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import type { McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { resolveEntityCode } from "../../utils/code-generator";
 import { resolveMemorySupersedes } from "../../utils/memory-utils";
 import { MEMORY_CONFLICT_THRESHOLD, TTL_MS_PER_DAY } from "../../utils/constants";
@@ -208,8 +209,7 @@ export async function checkCreateConflict(
 	db: SQLiteStore,
 	vectors: VectorStore,
 	isTaskArchive: boolean,
-	resolvedSupersedes: string | null,
-	json?: boolean
+	resolvedSupersedes: string | null
 ): Promise<{ conflict: boolean; response?: McpResponse }> {
 	if (resolvedSupersedes || isTaskArchive) {
 		return { conflict: false };
@@ -235,18 +235,16 @@ export async function checkCreateConflict(
 	if (conflict) {
 		return {
 			conflict: true,
-			response: createMcpResponse(
-				{
-					success: false,
-					error: "MEMORY_CONFLICT",
-					message: `This memory content overlaps significantly with an existing memory (ID: ${conflict.id}).`,
+			response: createMcpErrorResponse({
+				code: "MEMORY_CONFLICT",
+				message: `Rejected due to conflict: "${conflict.title}" (${conflict.id.slice(0, 8)}...). Hint: Use 'id' for update, 'id'+'acknowledge' for acknowledge, or 'supersedes' if replacing.`,
+				retryable: false,
+				details: {
 					conflicting_memory: { id: conflict.id, title: conflict.title, content: conflict.content },
 					instruction:
 						"Provide 'id' for update, 'id'+'acknowledge' for acknowledge, or 'supersedes' if this new memory replaces it."
-				},
-				`Rejected due to conflict: "${conflict.title}" (${conflict.id.slice(0, 8)}...). Hint: Use 'id' for update, 'id'+'acknowledge' for acknowledge, or 'supersedes' if replacing.`,
-				{ includeJson: json }
-			)
+				}
+			})
 		};
 	}
 

--- a/src/mcp/tools/memory.delete.ts
+++ b/src/mcp/tools/memory.delete.ts
@@ -1,6 +1,7 @@
 import { SQLiteStore } from "../storage/sqlite";
 import { VectorStore } from "../types";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
+import { createMcpErrorResponse } from "../utils/mcp-error";
 import { collectEntityIds } from "../utils/auto-infer";
 import { purgeEntityAndCleanup } from "../utils/purge-entity-cleanup";
 import { logger } from "../utils/logger";
@@ -85,20 +86,26 @@ export async function handleMemoryDelete(
 			? deletedCodes.join(", ")
 			: `${deletedCodes.slice(0, 3).join(", ")}, ... (${deletedCodes.length} total)`;
 
-	return createMcpResponse(
-		{
-			success: overallSuccess,
-			id: id || undefined,
-			ids: ids || undefined,
-			repo: lastRepo,
-			deletedCount,
-			deletedCodes: deletedCount > 10 ? [...deletedCodes.slice(0, 10), "..."] : deletedCodes,
-			...(skippedCount > 0 ? { skippedCount, errors: skippedErrors, totalAttempted: resolvedIds.length } : {})
-		},
-		`Deleted ${deletedCount} ${deletedCount === 1 ? "memory" : "memories"} from "${lastRepo}"${deletedCount > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`,
-		{
-			structuredContentPathHint: deletedCount > 0 ? "deletedCount" : "errors",
-			includeJson: json
-		}
-	);
+	const data = {
+		success: overallSuccess,
+		id: id || undefined,
+		ids: ids || undefined,
+		repo: lastRepo,
+		deletedCount,
+		deletedCodes: deletedCount > 10 ? [...deletedCodes.slice(0, 10), "..."] : deletedCodes,
+		...(skippedCount > 0 ? { skippedCount, errors: skippedErrors, totalAttempted: resolvedIds.length } : {})
+	};
+	const summary = `Deleted ${deletedCount} ${deletedCount === 1 ? "memory" : "memories"} from "${lastRepo}"${deletedCount > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`;
+	if (skippedCount > 0) {
+		return createMcpErrorResponse({
+			code: deletedCount > 0 ? "PARTIAL_FAILURE" : "BULK_OPERATION_FAILED",
+			message: summary,
+			retryable: false,
+			data
+		});
+	}
+	return createMcpResponse(data, summary, {
+		structuredContentPathHint: "deletedCount",
+		includeJson: json
+	});
 }

--- a/src/mcp/tools/schemas/agent.ts
+++ b/src/mcp/tools/schemas/agent.ts
@@ -1,14 +1,39 @@
 import { z } from "zod";
 
+export const AGENT_CONTEXT_SOURCES = [
+	"memories",
+	"decisions",
+	"tasks",
+	"handoffs",
+	"standards",
+	"observations",
+	"code"
+] as const;
+
 export const AgentContextSchema = z.object({
 	owner: z.string().min(1),
 	repo: z.string().min(1),
 	query: z
 		.string()
 		.optional()
-		.describe("Search query for vector/hybrid search. When absent, returns most recent memories."),
+		.describe("Backward-compatible search query. objective takes precedence when both are provided."),
+	objective: z.string().min(1).optional().describe("Current objective used to rank candidates from every source."),
+	task_code: z.string().min(1).optional().describe("Task to pin as critical context when it exists in scope."),
+	current_file_path: z.string().min(1).optional().describe("Indexed file used to retrieve compact code pointers."),
 	type_filter: z.enum(["code_fact", "decision", "mistake", "pattern", "task_archive"]).optional(),
 	limit: z.coerce.number().min(1).max(100).default(5),
+	budget: z
+		.object({
+			tokens: z.coerce.number().int().min(256).max(20_000).default(2_000),
+			max_items: z.coerce.number().int().min(1).max(100).default(20),
+			code_depth: z.coerce.number().int().min(0).max(5).default(1)
+		})
+		.default({ tokens: 2_000, max_items: 20, code_depth: 1 }),
+	sources: z
+		.array(z.enum(AGENT_CONTEXT_SOURCES))
+		.min(1)
+		.default([...AGENT_CONTEXT_SOURCES]),
+	include_stale: z.boolean().default(false),
 	json: z.boolean().default(false)
 });
 

--- a/src/mcp/tools/schemas/agent.ts
+++ b/src/mcp/tools/schemas/agent.ts
@@ -34,6 +34,18 @@ export const AgentContextSchema = z.object({
 		.min(1)
 		.default([...AGENT_CONTEXT_SOURCES]),
 	include_stale: z.boolean().default(false),
+	context_pack_id: z
+		.string()
+		.min(8)
+		.max(128)
+		.optional()
+		.describe("Stable opaque id for cache-hit correlation; never prompt text."),
+	session_id: z
+		.string()
+		.min(1)
+		.max(256)
+		.optional()
+		.describe("Opaque session correlation value; stored only as an in-memory hash."),
 	json: z.boolean().default(false)
 });
 

--- a/src/mcp/tools/schemas/codebase-index.ts
+++ b/src/mcp/tools/schemas/codebase-index.ts
@@ -17,6 +17,7 @@ export const CodebaseIndexSchema = z.object({
 	owner: z.string().min(1).optional(),
 	repo: z.string().min(1).transform(normalizeRepo),
 	repoPath: z.string().optional(),
+	warmup: z.boolean().optional(),
 	force: z.boolean().optional(),
 	includeGlobs: z.array(z.string()).optional(),
 	excludeGlobs: z.array(z.string()).optional()

--- a/src/mcp/tools/schemas/codebase-read.ts
+++ b/src/mcp/tools/schemas/codebase-read.ts
@@ -158,7 +158,7 @@ export const CodebaseReadSchema = z.object({
 	offset: z.coerce.number().min(0).default(0),
 
 	// ── Output ─────────────────────────────────────────────────────────────
-	/** Return raw JSON without Markdown wrapping. */
+	/** Include machine-readable structuredContent alongside the always-present compact text summary. */
 	json: z.boolean().default(false),
 	/**
 	 * Opt-in exposure of the optional semantic signatures (issue #89, TASK-015)

--- a/src/mcp/tools/schemas/exploration-observation.ts
+++ b/src/mcp/tools/schemas/exploration-observation.ts
@@ -6,7 +6,8 @@ export const ExplorationEvidenceSchema = z
 		file_path: z.string().min(1).max(1024),
 		symbol_id: z.string().min(1).max(255).nullable().optional(),
 		start_line: z.number().int().positive().nullable().optional(),
-		end_line: z.number().int().positive().nullable().optional()
+		end_line: z.number().int().positive().nullable().optional(),
+		commit_sha: z.string().min(7).max(64).nullable().optional()
 	})
 	.superRefine((item, ctx) => {
 		if (item.end_line && !item.start_line) {
@@ -31,7 +32,8 @@ export const ExplorationObservationItemSchema = z.object({
 	confidence: z.number().min(0).max(1),
 	evidence: z.array(ExplorationEvidenceSchema).min(1).max(50),
 	task_id: z.string().min(1).max(255).nullable().optional(),
-	agent: z.string().min(1).max(255).nullable().optional()
+	agent: z.string().min(1).max(255).nullable().optional(),
+	supersedes_id: z.string().uuid().nullable().optional()
 });
 
 export const ExplorationObservationWriteSchema = z
@@ -45,13 +47,22 @@ export const ExplorationObservationWriteSchema = z
 		evidence: z.array(ExplorationEvidenceSchema).min(1).max(50).optional(),
 		task_id: z.string().min(1).max(255).nullable().optional(),
 		agent: z.string().min(1).max(255).nullable().optional(),
+		supersedes_id: z.string().uuid().nullable().optional(),
 		observations: z.array(ExplorationObservationItemSchema).min(1).max(100).optional(),
+		refresh_ids: z.array(z.string().uuid()).min(1).max(100).optional(),
 		json: z.boolean().default(false)
 	})
 	.superRefine((data, ctx) => {
+		if (data.refresh_ids) {
+			if (data.id || data.observations || data.subject || data.fact || data.confidence !== undefined || data.evidence) {
+				ctx.addIssue({ code: "custom", message: "refresh_ids cannot be combined with create, update, or bulk fields" });
+			}
+			return;
+		}
 		if (data.observations && data.id)
 			ctx.addIssue({ code: "custom", message: "observations cannot be combined with id" });
 		if (data.observations) return;
+
 		for (const field of ["subject", "fact", "confidence", "evidence"] as const) {
 			if (data[field] === undefined) ctx.addIssue({ code: "custom", path: [field], message: `${field} is required` });
 		}
@@ -66,6 +77,7 @@ export const ExplorationObservationReadSchema = z.object({
 	file_path: z.string().min(1).optional(),
 	symbol_id: z.string().min(1).optional(),
 	min_confidence: z.number().min(0).max(1).default(0),
+	include_stale: z.boolean().default(false),
 	hydrate_evidence: z.boolean().default(false),
 	limit: z.coerce.number().int().min(1).max(100).default(20),
 	offset: z.coerce.number().int().min(0).default(0),

--- a/src/mcp/tools/schemas/exploration-observation.ts
+++ b/src/mcp/tools/schemas/exploration-observation.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { normalizeRepo } from "../../utils/normalize";
+
+export const ExplorationEvidenceSchema = z
+	.object({
+		file_path: z.string().min(1).max(1024),
+		symbol_id: z.string().min(1).max(255).nullable().optional(),
+		start_line: z.number().int().positive().nullable().optional(),
+		end_line: z.number().int().positive().nullable().optional()
+	})
+	.superRefine((item, ctx) => {
+		if (item.end_line && !item.start_line) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["start_line"],
+				message: "start_line is required when end_line is provided"
+			});
+		}
+		if (item.start_line && item.end_line && item.end_line < item.start_line) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["end_line"],
+				message: "end_line must be greater than or equal to start_line"
+			});
+		}
+	});
+
+export const ExplorationObservationItemSchema = z.object({
+	subject: z.string().trim().min(1).max(255),
+	fact: z.string().trim().min(10).max(5000),
+	confidence: z.number().min(0).max(1),
+	evidence: z.array(ExplorationEvidenceSchema).min(1).max(50),
+	task_id: z.string().min(1).max(255).nullable().optional(),
+	agent: z.string().min(1).max(255).nullable().optional()
+});
+
+export const ExplorationObservationWriteSchema = z
+	.object({
+		owner: z.string().min(1),
+		repo: z.string().min(1).transform(normalizeRepo),
+		id: z.string().uuid().optional(),
+		subject: z.string().trim().min(1).max(255).optional(),
+		fact: z.string().trim().min(10).max(5000).optional(),
+		confidence: z.number().min(0).max(1).optional(),
+		evidence: z.array(ExplorationEvidenceSchema).min(1).max(50).optional(),
+		task_id: z.string().min(1).max(255).nullable().optional(),
+		agent: z.string().min(1).max(255).nullable().optional(),
+		observations: z.array(ExplorationObservationItemSchema).min(1).max(100).optional(),
+		json: z.boolean().default(false)
+	})
+	.superRefine((data, ctx) => {
+		if (data.observations && data.id)
+			ctx.addIssue({ code: "custom", message: "observations cannot be combined with id" });
+		if (data.observations) return;
+		for (const field of ["subject", "fact", "confidence", "evidence"] as const) {
+			if (data[field] === undefined) ctx.addIssue({ code: "custom", path: [field], message: `${field} is required` });
+		}
+	});
+
+export const ExplorationObservationReadSchema = z.object({
+	owner: z.string().min(1),
+	repo: z.string().min(1).transform(normalizeRepo),
+	id: z.string().uuid().optional(),
+	subject: z.string().min(1).optional(),
+	task_id: z.string().min(1).optional(),
+	file_path: z.string().min(1).optional(),
+	symbol_id: z.string().min(1).optional(),
+	min_confidence: z.number().min(0).max(1).default(0),
+	hydrate_evidence: z.boolean().default(false),
+	limit: z.coerce.number().int().min(1).max(100).default(20),
+	offset: z.coerce.number().int().min(0).default(0),
+	json: z.boolean().default(false)
+});
+
+export type ExplorationObservationWriteInput = z.infer<typeof ExplorationObservationWriteSchema>;
+export type ExplorationObservationReadInput = z.infer<typeof ExplorationObservationReadSchema>;

--- a/src/mcp/tools/schemas/index.ts
+++ b/src/mcp/tools/schemas/index.ts
@@ -45,3 +45,11 @@ export { IndexRepoSchema, IndexStatusSchema, CodebaseIndexSchema } from "./codeb
 
 export { CodebaseReadSchema } from "./codebase-read";
 export type { CodebaseReadInput, CodebaseReadMode } from "./codebase-read";
+
+export {
+	ExplorationEvidenceSchema,
+	ExplorationObservationItemSchema,
+	ExplorationObservationWriteSchema,
+	ExplorationObservationReadSchema
+} from "./exploration-observation";
+export type { ExplorationObservationWriteInput, ExplorationObservationReadInput } from "./exploration-observation";

--- a/src/mcp/tools/standard-read/search.ts
+++ b/src/mcp/tools/standard-read/search.ts
@@ -306,12 +306,13 @@ export async function handleSearchMode(
 
 	const responseData = buildTableResult(SEARCH_COLUMNS, rows, {
 		schema: "standard-read",
+		mode: "search",
 		key: "results",
 		count: paginatedResults.length,
 		total,
 		offset: validated.offset,
 		limit: validated.limit,
-		extra: { mode: "search", query: validated.query || "" }
+		extra: { query: validated.query || "" }
 	});
 
 	// Best-effort KG context (REFACTOR-KG-005) — gated on the json flag

--- a/src/mcp/tools/standard-write/bulk.ts
+++ b/src/mcp/tools/standard-write/bulk.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "crypto";
 import { CodingStandardEntry, VectorStore } from "../../types";
 import { SQLiteStore } from "../../storage/sqlite";
 import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { enqueueStandard } from "../../embedding-queue";
 import { StandardWriteParams, BulkResult, resolveStandardParentId, toContextSlug, generateNextCode } from "./shared";
 
@@ -103,23 +104,29 @@ export async function handleBulk(
 	const failed = results.filter((r) => !r.success);
 	const allOk = failed.length === 0;
 
-	return createMcpResponse(
-		{
-			success: allOk,
-			total: items.length,
-			processed: succeeded.length,
-			...(failed.length > 0 ? { errors: failed.map((r) => ({ index: r.index, error: r.error })) } : {}),
-			results: results.map((r) => ({
-				index: r.index,
-				operation: r.operation,
-				success: r.success,
-				...(r.id ? { id: r.id } : {}),
-				...(r.code ? { code: r.code } : {}),
-				...(r.title ? { title: r.title } : {}),
-				...(r.error ? { error: r.error } : {})
-			}))
-		},
-		`Processed ${succeeded.length}/${items.length} items${failed.length > 0 ? ` (${failed.length} failed)` : ""}.`,
-		{ includeJson: params.json }
-	);
+	const data = {
+		success: allOk,
+		total: items.length,
+		processed: succeeded.length,
+		...(failed.length > 0 ? { errors: failed.map((r) => ({ index: r.index, error: r.error })) } : {}),
+		results: results.map((r) => ({
+			index: r.index,
+			operation: r.operation,
+			success: r.success,
+			...(r.id ? { id: r.id } : {}),
+			...(r.code ? { code: r.code } : {}),
+			...(r.title ? { title: r.title } : {}),
+			...(r.error ? { error: r.error } : {})
+		}))
+	};
+	const summary = `Processed ${succeeded.length}/${items.length} items${failed.length > 0 ? ` (${failed.length} failed)` : ""}.`;
+	if (!allOk) {
+		return createMcpErrorResponse({
+			code: succeeded.length > 0 ? "PARTIAL_FAILURE" : "BULK_OPERATION_FAILED",
+			message: summary,
+			retryable: false,
+			data
+		});
+	}
+	return createMcpResponse(data, summary, { includeJson: params.json });
 }

--- a/src/mcp/tools/standard-write/create.ts
+++ b/src/mcp/tools/standard-write/create.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "crypto";
 import { CodingStandardEntry, VectorStore } from "../../types";
 import { SQLiteStore } from "../../storage/sqlite";
 import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { enqueueStandard } from "../../embedding-queue";
 import { StandardWriteParams, resolveStandardParentId, toContextSlug, generateNextCode } from "./shared";
 
@@ -127,8 +128,12 @@ export async function handleCreateSingle(
 	} catch (err: unknown) {
 		const conflictErr = err as Error & { structured?: Record<string, unknown> };
 		if (conflictErr.structured) {
-			return createMcpResponse(conflictErr.structured, `Rejected: conflicts with existing standard.`, {
-				includeJson: params.json
+			const { error, message, success: _success, ...details } = conflictErr.structured;
+			return createMcpErrorResponse({
+				code: String(error),
+				message: String(message),
+				retryable: false,
+				details
 			});
 		}
 		throw err;

--- a/src/mcp/tools/standard-write/update.ts
+++ b/src/mcp/tools/standard-write/update.ts
@@ -6,6 +6,7 @@ import { CodingStandardEntry, VectorStore } from "../../types";
 import { SQLiteStore } from "../../storage/sqlite";
 import { logger } from "../../utils/logger";
 import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { resolveEntityRef } from "../../utils/entity-ref";
 import { enqueueStandard } from "../../embedding-queue";
 import { StandardWriteParams, resolveStandardParentId } from "./shared";
@@ -156,8 +157,12 @@ export async function handleUpdateSingle(
 	} catch (err: unknown) {
 		const conflictErr = err as Error & { structured?: Record<string, unknown> };
 		if (conflictErr.structured) {
-			return createMcpResponse(conflictErr.structured, `Rejected: update conflicts with existing standard.`, {
-				includeJson: params.json
+			const { error, message, success: _success, ...details } = conflictErr.structured;
+			return createMcpErrorResponse({
+				code: String(error),
+				message: String(message),
+				retryable: false,
+				details
 			});
 		}
 		throw err;

--- a/src/mcp/tools/standard.delete.ts
+++ b/src/mcp/tools/standard.delete.ts
@@ -1,6 +1,7 @@
 import { SQLiteStore } from "../storage/sqlite";
 import { VectorStore } from "../types";
 import { createMcpResponse, McpResponse } from "../utils/mcp-response";
+import { createMcpErrorResponse } from "../utils/mcp-error";
 import { collectEntityIds } from "../utils/auto-infer";
 import { purgeEntityAndCleanup } from "../utils/purge-entity-cleanup";
 import { logger } from "../utils/logger";
@@ -100,11 +101,14 @@ export async function handleStandardDelete(
 		responseData.totalAttempted = resolvedIds.length;
 	}
 
-	return createMcpResponse(
-		responseData,
-		`Deleted ${deletedCount} ${deletedCount === 1 ? "standard" : "standards"} from "${lastRepo}"${deletedCodes.length > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`,
-		{
-			includeJson: json
-		}
-	);
+	const summary = `Deleted ${deletedCount} ${deletedCount === 1 ? "standard" : "standards"} from "${lastRepo}"${deletedCodes.length > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`;
+	if (skippedCount > 0) {
+		return createMcpErrorResponse({
+			code: deletedCount > 0 ? "PARTIAL_FAILURE" : "BULK_OPERATION_FAILED",
+			message: summary,
+			retryable: false,
+			data: responseData
+		});
+	}
+	return createMcpResponse(responseData, summary, { includeJson: json });
 }

--- a/src/mcp/tools/task-read/detail.ts
+++ b/src/mcp/tools/task-read/detail.ts
@@ -1,6 +1,6 @@
 import { SQLiteStore } from "../../storage/sqlite";
 import { Task, TaskChild, TaskComment } from "../../types";
-import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpResponse, McpResponse, withEnvelope } from "../../utils/mcp-response";
 import { UUID_REGEX } from "../../utils/uuid";
 import { logger } from "../../utils/logger";
 import { fetchTaskKgContext } from "../kg-archivist/query";
@@ -111,7 +111,7 @@ export async function handleDetailMode(
 		const depended_by = storage.tasks.getDependedByTaskId(task.id);
 
 		let contentSummary: string | undefined;
-		if (!isJsonRequest) {
+		{
 			contentSummary = buildTaskDetailLines(task, comments, children, depended_by).join("\n");
 		}
 
@@ -127,7 +127,7 @@ export async function handleDetailMode(
 		};
 		if (kgContext) data.kg = kgContext;
 
-		return createMcpResponse(data, contentSummary || "", {
+		return createMcpResponse(withEnvelope("task-read/detail", "detail", data), contentSummary || "", {
 			contentSummary,
 			includeJson: isJsonRequest
 		});
@@ -175,7 +175,7 @@ export async function handleDetailMode(
 		: null;
 
 	let contentSummary: string | undefined;
-	if (!isJsonRequest) {
+	{
 		const sections: string[] = [`${enriched.length} task details — repo "${repo}"`];
 		for (const entry of enriched) {
 			sections.push("");
@@ -196,6 +196,7 @@ export async function handleDetailMode(
 
 	const data: Record<string, unknown> = {
 		schema: "task-read/detail" as const,
+		mode: "detail" as const,
 		count: enriched.length,
 		tasks: enriched
 	};

--- a/src/mcp/tools/task-read/list.ts
+++ b/src/mcp/tools/task-read/list.ts
@@ -46,6 +46,7 @@ export async function handleListMode(
 
 	const structuredData = buildTableResult(COLUMNS, rows, {
 		schema: "task-read/list",
+		mode: "list",
 		key: "tasks",
 		count: rows.length,
 		offset
@@ -61,7 +62,7 @@ export async function handleListMode(
 	}
 
 	let contentSummary: string | undefined;
-	if (!isJsonRequest) {
+	{
 		const statusLabel = describeStatusFilter(effectiveStatus);
 		const taskLabel = rows.length === 1 ? "task" : "tasks";
 

--- a/src/mcp/tools/task-read/search.ts
+++ b/src/mcp/tools/task-read/search.ts
@@ -319,6 +319,7 @@ export async function handleSearchMode(
 
 	const structuredData = buildTableResult(COLUMNS, rows, {
 		schema: "task-read/search",
+		mode: "search",
 		key: "results",
 		count: paginated.length,
 		total,
@@ -339,7 +340,7 @@ export async function handleSearchMode(
 	}
 
 	let contentSummary: string | undefined;
-	if (!isJsonRequest) {
+	{
 		if (scoredPool.length > 0) {
 			const lines: string[] = [];
 			// Header shows TOTAL matches; the grouped body below represents the

--- a/src/mcp/tools/task-write/bulk.ts
+++ b/src/mcp/tools/task-write/bulk.ts
@@ -1,6 +1,7 @@
 import { SQLiteStore } from "../../storage/sqlite";
 import { TaskStatus, VectorStore, TASK_STATUS_BACKLOG } from "../../types";
 import { createMcpResponse, McpResponse } from "../../utils/mcp-response";
+import { createMcpErrorResponse } from "../../utils/mcp-error";
 import { extractAcceptedElicitationContent } from "../../elicitation";
 import { handleCreateSingle } from "./create";
 import { executeBulkOperation } from "./bulk-executor";
@@ -163,15 +164,12 @@ export async function handleBulk(
 			throw new Error(failed[0].error as string);
 		}
 		// Partial failure — return error response with results
-		return {
-			isError: true,
-			content: [
-				{
-					type: "text",
-					text: `Processed ${succeeded.length}/${items.length} in "${repo}" (${failed.length} failed). Errors: ${failed.map((r) => `[${r.index}] ${r.error}`).join("; ")}`
-				}
-			],
-			structuredContent: {
+		const message = `Processed ${succeeded.length}/${items.length} in "${repo}" (${failed.length} failed). Errors: ${failed.map((r) => `[${r.index}] ${r.error}`).join("; ")}`;
+		return createMcpErrorResponse({
+			code: "PARTIAL_FAILURE",
+			message,
+			retryable: false,
+			data: {
 				success: false,
 				repo,
 				total: items.length,
@@ -187,7 +185,7 @@ export async function handleBulk(
 					return res;
 				})
 			}
-		};
+		});
 	}
 
 	// Build summary text matching test expectations

--- a/src/mcp/tools/task.delete.ts
+++ b/src/mcp/tools/task.delete.ts
@@ -1,5 +1,6 @@
 import { SQLiteStore } from "../storage/sqlite";
 import { createMcpResponse } from "../utils/mcp-response";
+import { createMcpErrorResponse } from "../utils/mcp-error";
 import { collectEntityIds } from "../utils/auto-infer";
 import { purgeEntityAndCleanup } from "../utils/purge-entity-cleanup";
 import { logger } from "../utils/logger";
@@ -77,21 +78,27 @@ export async function handleTaskDelete(args: unknown, storage: SQLiteStore) {
 			? deletedCodes.join(", ")
 			: `${deletedCodes.slice(0, 3).join(", ")}, ... (${deletedCodes.length} total)`;
 
-	return createMcpResponse(
-		{
-			success: overallSuccess,
-			id: id || undefined,
-			code: code || undefined,
-			ids: ids || undefined,
-			codes: codes || undefined,
-			task_code: task_code || undefined,
-			task_codes: task_codes || undefined,
-			repo,
-			canceledCount: deletedCount,
-			canceledCodes: deletedCodes,
-			...(skippedCount > 0 ? { skippedCount, errors: skippedErrors, totalAttempted: resolvedIds.length } : {})
-		},
-		`Deleted ${deletedCount} ${deletedCount === 1 ? "task" : "tasks"} from "${repo}"${deletedCodes.length > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`,
-		{ includeJson: validated.json }
-	);
+	const data = {
+		success: overallSuccess,
+		id: id || undefined,
+		code: code || undefined,
+		ids: ids || undefined,
+		codes: codes || undefined,
+		task_code: task_code || undefined,
+		task_codes: task_codes || undefined,
+		repo,
+		canceledCount: deletedCount,
+		canceledCodes: deletedCodes,
+		...(skippedCount > 0 ? { skippedCount, errors: skippedErrors, totalAttempted: resolvedIds.length } : {})
+	};
+	const summary = `Deleted ${deletedCount} ${deletedCount === 1 ? "task" : "tasks"} from "${repo}"${deletedCodes.length > 0 ? `: ${codeSample}` : ""}${skippedCount > 0 ? ` (${skippedCount} skipped)` : ""}.`;
+	if (skippedCount > 0) {
+		return createMcpErrorResponse({
+			code: deletedCount > 0 ? "PARTIAL_FAILURE" : "BULK_OPERATION_FAILED",
+			message: summary,
+			retryable: false,
+			data
+		});
+	}
+	return createMcpResponse(data, summary, { includeJson: validated.json });
 }

--- a/src/mcp/types/codebase-symbol.ts
+++ b/src/mcp/types/codebase-symbol.ts
@@ -34,6 +34,7 @@ export interface CodebaseSymbol {
 	semantic_source?: string | null;
 	/** ISO timestamp of the last successful semantic-enrichment pass (issue #89). */
 	semantic_updated_at?: string | null;
+	source_fingerprint?: string | null;
 	created_at: string;
 	updated_at: string;
 }
@@ -56,6 +57,7 @@ export interface CodebaseSymbolRow {
 	semantic_signature: string | null;
 	semantic_source: string | null;
 	semantic_updated_at: string | null;
+	source_fingerprint: string | null;
 	created_at: string;
 	updated_at: string;
 }
@@ -90,6 +92,8 @@ export interface CodebaseSymbolInsert {
 	semantic_source?: string | null;
 	/** ISO timestamp of the last semantic-enrichment pass. */
 	semantic_updated_at?: string | null;
+	/** SHA-256 of the indexed source range for freshness checks. */
+	source_fingerprint?: string | null;
 }
 
 export interface SymbolSearchQuery {

--- a/src/mcp/types/exploration-observation.ts
+++ b/src/mcp/types/exploration-observation.ts
@@ -1,0 +1,48 @@
+export type ObservationFreshness = "valid" | "stale" | "unverifiable";
+
+export interface ExplorationEvidenceInput {
+	file_path: string;
+	symbol_id?: string | null;
+	start_line?: number | null;
+	end_line?: number | null;
+}
+
+export interface ExplorationEvidence extends ExplorationEvidenceInput {
+	id: string;
+	observation_id: string;
+	created_at: string;
+}
+
+export interface ExplorationObservationInput {
+	subject: string;
+	fact: string;
+	confidence: number;
+	evidence: ExplorationEvidenceInput[];
+	task_id?: string | null;
+	agent?: string | null;
+}
+
+export interface ExplorationObservation {
+	id: string;
+	owner: string;
+	repo: string;
+	subject: string;
+	fact: string;
+	confidence: number;
+	task_id: string | null;
+	agent: string | null;
+	identity_hash: string;
+	freshness: ObservationFreshness;
+	created_at: string;
+	updated_at: string;
+	evidence_count: number;
+	evidence?: ExplorationEvidence[];
+}
+
+export interface ExplorationObservationRow extends Omit<
+	ExplorationObservation,
+	"confidence" | "evidence_count" | "evidence"
+> {
+	confidence: number;
+	evidence_count?: number;
+}

--- a/src/mcp/types/exploration-observation.ts
+++ b/src/mcp/types/exploration-observation.ts
@@ -5,11 +5,16 @@ export interface ExplorationEvidenceInput {
 	symbol_id?: string | null;
 	start_line?: number | null;
 	end_line?: number | null;
+	commit_sha?: string | null;
 }
 
 export interface ExplorationEvidence extends ExplorationEvidenceInput {
 	id: string;
 	observation_id: string;
+	file_checksum: string | null;
+	symbol_fingerprint: string | null;
+	indexed_at: string | null;
+	commit_sha: string | null;
 	created_at: string;
 }
 
@@ -20,6 +25,7 @@ export interface ExplorationObservationInput {
 	evidence: ExplorationEvidenceInput[];
 	task_id?: string | null;
 	agent?: string | null;
+	supersedes_id?: string | null;
 }
 
 export interface ExplorationObservation {
@@ -33,6 +39,9 @@ export interface ExplorationObservation {
 	agent: string | null;
 	identity_hash: string;
 	freshness: ObservationFreshness;
+	stale_reason: string | null;
+	last_verified_at: string | null;
+	superseded_by: string | null;
 	created_at: string;
 	updated_at: string;
 	evidence_count: number;

--- a/src/mcp/types/index.ts
+++ b/src/mcp/types/index.ts
@@ -8,6 +8,7 @@ export * from "./handoff";
 export * from "./codebase-file";
 export * from "./codebase-symbol";
 export * from "./codebase-reference";
+export * from "./exploration-observation";
 
 import { MemoryEntry } from "./memory";
 export type Memory = MemoryEntry;

--- a/src/mcp/types/tool-definitions/agent.ts
+++ b/src/mcp/types/tool-definitions/agent.ts
@@ -14,8 +14,9 @@ export const AGENT_TOOL_DEFINITIONS = [
 	// ── Agent Context tools ────────────────────────────────────────────────
 	{
 		name: "agent-context",
-		title: "Agent Context Recall",
-		description: "Agent context with memories and tasks.",
+		title: "Agent Context Compiler",
+		description:
+			"Compiles deterministic, token-budgeted context from memories, decisions, tasks, handoffs, standards, fresh observations, and indexed code pointers.",
 		annotations: {
 			readOnlyHint: true,
 			idempotentHint: true,

--- a/src/mcp/types/tool-definitions/codebase-index.ts
+++ b/src/mcp/types/tool-definitions/codebase-index.ts
@@ -27,7 +27,8 @@ export const CODEBASE_INDEX_TOOL_DEFINITIONS = [
 			"Unified tool for codebase index management. " +
 			"Auto-infers mode from params: " +
 			"`repoPath` + `repo` → index (tree-sitter scan, replaces index_repository); " +
-			"`repo` saja (tanpa repoPath) → status (freshness + count, replaces index_status).",
+			"`repo` saja (tanpa repoPath) → status (freshness + runtime capability state); " +
+			"`warmup:true` explicitly initializes the index engine.",
 		annotations: {
 			readOnlyHint: false,
 			idempotentHint: true,

--- a/src/mcp/types/tool-definitions/exploration-observation.ts
+++ b/src/mcp/types/tool-definitions/exploration-observation.ts
@@ -1,0 +1,24 @@
+import {
+	ExplorationObservationReadSchema,
+	ExplorationObservationWriteSchema
+} from "../../tools/schemas/exploration-observation";
+import { inputSchemaFromSchema } from "../../tools/schemas/json-schema";
+
+export const EXPLORATION_OBSERVATION_TOOL_DEFINITIONS = [
+	{
+		name: "observation-write",
+		title: "Exploration Observation Write",
+		description:
+			"Creates, updates, or atomically bulk-creates high-signal exploration observations with source evidence. Repeated normalized facts and evidence are idempotent.",
+		annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false, openWorldHint: false },
+		inputSchema: inputSchemaFromSchema(ExplorationObservationWriteSchema)
+	},
+	{
+		name: "observation-read",
+		title: "Exploration Observation Read",
+		description:
+			"Reads evidence-backed exploration observations by scope, id, subject, task, file, symbol, or minimum confidence. Evidence is hydrated only when requested.",
+		annotations: { readOnlyHint: true, idempotentHint: true, destructiveHint: false, openWorldHint: false },
+		inputSchema: inputSchemaFromSchema(ExplorationObservationReadSchema)
+	}
+];

--- a/src/mcp/types/tool-definitions/exploration-observation.ts
+++ b/src/mcp/types/tool-definitions/exploration-observation.ts
@@ -9,7 +9,7 @@ export const EXPLORATION_OBSERVATION_TOOL_DEFINITIONS = [
 		name: "observation-write",
 		title: "Exploration Observation Write",
 		description:
-			"Creates, updates, or atomically bulk-creates high-signal exploration observations with source evidence. Repeated normalized facts and evidence are idempotent.",
+			"Creates, updates, supersedes, atomically bulk-creates, or explicitly refreshes high-signal exploration observations with source fingerprints. Repeated normalized facts and evidence are idempotent.",
 		annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false, openWorldHint: false },
 		inputSchema: inputSchemaFromSchema(ExplorationObservationWriteSchema)
 	},
@@ -17,7 +17,7 @@ export const EXPLORATION_OBSERVATION_TOOL_DEFINITIONS = [
 		name: "observation-read",
 		title: "Exploration Observation Read",
 		description:
-			"Reads evidence-backed exploration observations by scope, id, subject, task, file, symbol, or minimum confidence. Evidence is hydrated only when requested.",
+			"Reads evidence-backed exploration observations by scope, id, subject, task, file, symbol, or minimum confidence. Stale and unverifiable findings are excluded by default; evidence and fingerprint refresh are explicit.",
 		annotations: { readOnlyHint: true, idempotentHint: true, destructiveHint: false, openWorldHint: false },
 		inputSchema: inputSchemaFromSchema(ExplorationObservationReadSchema)
 	}

--- a/src/mcp/types/tool-definitions/index.ts
+++ b/src/mcp/types/tool-definitions/index.ts
@@ -5,6 +5,7 @@ import { HANDOFF_TOOL_DEFINITIONS } from "./handoff";
 import { STANDARD_TOOL_DEFINITIONS } from "./standard";
 import { AGENT_TOOL_DEFINITIONS } from "./agent";
 import { CODEBASE_INDEX_TOOL_DEFINITIONS } from "./codebase-index";
+import { EXPLORATION_OBSERVATION_TOOL_DEFINITIONS } from "./exploration-observation";
 
 export { MEMORY_TOOL_DEFINITIONS } from "./memory";
 export { TASK_TOOL_DEFINITIONS } from "./task";
@@ -12,6 +13,7 @@ export { HANDOFF_TOOL_DEFINITIONS } from "./handoff";
 export { STANDARD_TOOL_DEFINITIONS } from "./standard";
 export { AGENT_TOOL_DEFINITIONS } from "./agent";
 export { CODEBASE_INDEX_TOOL_DEFINITIONS } from "./codebase-index";
+export { EXPLORATION_OBSERVATION_TOOL_DEFINITIONS } from "./exploration-observation";
 
 export const TOOL_DEFINITIONS = [
 	...MEMORY_TOOL_DEFINITIONS,
@@ -19,5 +21,6 @@ export const TOOL_DEFINITIONS = [
 	...HANDOFF_TOOL_DEFINITIONS,
 	...STANDARD_TOOL_DEFINITIONS,
 	...AGENT_TOOL_DEFINITIONS,
-	...CODEBASE_INDEX_TOOL_DEFINITIONS
+	...CODEBASE_INDEX_TOOL_DEFINITIONS,
+	...EXPLORATION_OBSERVATION_TOOL_DEFINITIONS
 ];

--- a/src/mcp/types/vector.ts
+++ b/src/mcp/types/vector.ts
@@ -6,6 +6,8 @@ export type VectorResult = {
 export type VectorEntityKind = "memory" | "standard" | "task" | "codebase_symbol";
 
 export interface VectorStore {
+	initialize?(): Promise<void>;
+	embed?(texts: string[]): Promise<number[][]>;
 	upsert(id: string, text: string, kind?: VectorEntityKind): Promise<void>;
 	remove(id: string, kind?: VectorEntityKind): Promise<void>;
 	search(query: string, limit: number, repo?: string, kind?: VectorEntityKind): Promise<VectorResult[]>;

--- a/src/mcp/utils/mcp-error.ts
+++ b/src/mcp/utils/mcp-error.ts
@@ -1,6 +1,73 @@
 import { ZodError, z } from "zod";
 import type { McpResponse } from "./mcp-response";
 
+export type ToolErrorCode =
+	| "VALIDATION_ERROR"
+	| "NOT_FOUND"
+	| "CONFLICT"
+	| "UNSUPPORTED_OPERATION"
+	| "CAPABILITY_UNAVAILABLE"
+	| "INTERNAL_ERROR"
+	| (string & {});
+
+export interface ToolErrorEnvelope {
+	schema: "tool-error";
+	code: ToolErrorCode;
+	message: string;
+	retryable: boolean;
+	details?: Record<string, unknown>;
+}
+
+export interface ToolErrorOptions {
+	retryable?: boolean;
+	details?: Record<string, unknown>;
+}
+
+export interface McpErrorResponseOptions extends ToolErrorOptions {
+	/** Additional top-level fields retained for backward-compatible partial-result envelopes. */
+	data?: Record<string, unknown>;
+}
+
+/** Expected, caller-actionable tool failure with a stable machine code. */
+export class ToolError extends Error {
+	readonly code: ToolErrorCode;
+	readonly retryable: boolean;
+	readonly details?: Record<string, unknown>;
+
+	constructor(code: ToolErrorCode, message: string, options: ToolErrorOptions = {}) {
+		super(message);
+		this.name = "ToolError";
+		this.code = code;
+		this.retryable = options.retryable ?? false;
+		this.details = options.details;
+	}
+}
+
+export function createMcpErrorResponse(error: {
+	code: ToolErrorCode;
+	message: string;
+	retryable?: boolean;
+	details?: Record<string, unknown>;
+	data?: Record<string, unknown>;
+}): McpResponse {
+	const envelope: ToolErrorEnvelope & Record<string, unknown> = {
+		...error.data,
+		...error.details,
+		schema: "tool-error",
+		code: error.code,
+		message: error.message,
+		retryable: error.retryable ?? false,
+		// Backward-compatible alias used by existing dashboard and clients.
+		error: error.message,
+		...(error.details ? { details: error.details } : {})
+	};
+	return {
+		content: [{ type: "text", text: error.message }],
+		structuredContent: envelope,
+		isError: true
+	};
+}
+
 /**
  * ── Canonical error envelope (OPT-CODE-01) ────────────────────────────────
  *
@@ -22,29 +89,63 @@ import type { McpResponse } from "./mcp-response";
  * working.
  */
 export function toErrorResponse(err: unknown): McpResponse {
-	return {
-		content: [{ type: "text" as const, text: toErrorMessage(err) }],
-		isError: true
-	};
+	if (err instanceof ToolError) {
+		return createMcpErrorResponse({
+			code: err.code,
+			message: err.message,
+			retryable: err.retryable,
+			details: err.details
+		});
+	}
+	if (err instanceof ZodError) {
+		return createMcpErrorResponse({
+			code: "VALIDATION_ERROR",
+			message: `Error: ${formatZodError(err)}`,
+			retryable: false
+		});
+	}
+	if (err instanceof Error) {
+		const classified = classifyExpectedError(err);
+		if (classified) return createMcpErrorResponse(classified);
+	}
+	return createMcpErrorResponse({
+		code: "INTERNAL_ERROR",
+		message: "Internal tool error",
+		retryable: false
+	});
 }
 
-/**
- * Message derivation for {@link toErrorResponse}.
- *
- * - `ZodError` → friendly validation text via {@link formatZodError} (the raw
- *   Zod `.message` is a serialized JSON issue dump, useless to a caller).
- * - `Error`   → `err.message` (unchanged, preserves all domain messages like
- *   "Task not found: …" thrown by handlers).
- * - anything else → `String(err)` fallback.
- */
-function toErrorMessage(err: unknown): string {
-	if (err instanceof ZodError) {
-		return `Error: ${formatZodError(err)}`;
+function classifyExpectedError(error: Error): {
+	code: ToolErrorCode;
+	message: string;
+	retryable: boolean;
+	details?: Record<string, unknown>;
+} | null {
+	const structured = (error as Error & { structured?: Record<string, unknown> }).structured;
+	if (structured && typeof structured.error === "string" && typeof structured.message === "string") {
+		const { error: code, message, success: _success, ...details } = structured;
+		return { code, message, retryable: false, ...(Object.keys(details).length > 0 ? { details } : {}) };
 	}
-	if (err instanceof Error && err.message) {
-		return `Error: ${err.message}`;
+	if (/\bnot found\b/i.test(error.message)) {
+		return { code: "NOT_FOUND", message: error.message, retryable: false };
 	}
-	return `Error: ${String(err)}`;
+	if (
+		/^(?:Missing|required|Either|At least|Provide|Invalid|No .* provided|New .* must|CREATE requires|UPDATE requires)/i.test(
+			error.message
+		) ||
+		/\bmust be\b|\bis required\b|\brequire(?:s)? type=|\bvalidation\b|\bappears to contain metadata\b|\bcompleted-work summaries\b/i.test(
+			error.message
+		)
+	) {
+		return { code: "VALIDATION_ERROR", message: error.message, retryable: false };
+	}
+	if (/\b(?:already exists|duplicate|conflict)\b/i.test(error.message)) {
+		return { code: "CONFLICT", message: error.message, retryable: false };
+	}
+	if (/\bunsupported\b/i.test(error.message)) {
+		return { code: "UNSUPPORTED_OPERATION", message: error.message, retryable: false };
+	}
+	return null;
 }
 
 /**

--- a/src/mcp/utils/mcp-response.ts
+++ b/src/mcp/utils/mcp-response.ts
@@ -85,14 +85,16 @@ export function createMcpResponse(
 	}
 
 	const content: McpContent[] = [];
+	const normalizedContentSummary = contentSummary?.trim();
+	const normalizedSummary = summary.trim() || "Request completed.";
 
-	if (contentSummary && contentSummary.trim().length > 0) {
+	if (normalizedContentSummary) {
 		content.push({
 			type: "text",
-			text: contentSummary.trim()
+			text: normalizedContentSummary
 		});
-	} else if (summary && summary.trim().length > 0) {
-		let text = summary.trim();
+	} else {
+		let text = normalizedSummary;
 		const hasStructuredContent =
 			finalData != null &&
 			typeof finalData === "object" &&
@@ -173,6 +175,8 @@ export function createTextOnlyResponse(text: string): McpResponse {
 export type TableResultOptions = {
 	/** Optional top-level `schema` discriminator (e.g. "task-read/search"). */
 	schema?: string;
+	/** Optional stable mode discriminator. */
+	mode?: string;
 	/**
 	 * Optional key under which the `{ columns, rows }` table is nested
 	 * (e.g. "results", "tasks", "handoffs", "claims"). When omitted, the
@@ -187,14 +191,14 @@ export type TableResultOptions = {
 	offset?: number;
 	/** Optional pagination limit. */
 	limit?: number;
-	/** Optional additional top-level fields merged into the envelope (e.g. `query`, `mode`). */
+	/** Optional additional top-level fields merged into the envelope (e.g. `query`). */
 	extra?: Record<string, unknown>;
 };
 
 /**
  * Builds the shared table envelope scaffold:
  *
- *   `{ schema?, <key>?: { columns, rows }, count, total?, offset?, limit? }`
+ *   `{ schema?, mode?, <key>?: { columns, rows }, count, total?, offset?, limit? }`
  *
  * This encapsulates the `COLUMNS = [...] as const` + `rows.map` +
  * `structuredData = { schema, <kind>: { columns, rows }, count, total, offset, limit }`
@@ -211,13 +215,16 @@ export function buildTableResult(
 	rows: readonly unknown[][],
 	options: TableResultOptions = {}
 ): Record<string, unknown> {
-	const { schema, key, count = rows.length, total, offset, limit, extra } = options;
+	const { schema, mode, key, count = rows.length, total, offset, limit, extra } = options;
 
 	const table = { columns: [...columns], rows };
 	const result: Record<string, unknown> = {};
 
 	if (schema !== undefined) {
 		result.schema = schema;
+	}
+	if (mode !== undefined) {
+		result.mode = mode;
 	}
 	if (extra) {
 		Object.assign(result, extra);
@@ -234,6 +241,29 @@ export function buildTableResult(
 	if (limit !== undefined) result.limit = limit;
 
 	return result;
+}
+
+/**
+ * Prepends the two stable envelope discriminators to an existing structured
+ * payload without renaming or duplicating any field (issue #99).
+ *
+ * `schema` identifies the producing tool, `mode` the auto-inferred branch, so a
+ * client can dispatch on `(schema, mode)` instead of probing for domain keys
+ * (`memory` vs `standard` vs a flattened task). Every legacy key is preserved
+ * verbatim at its current path, so no compatibility alias is required — the
+ * envelope only grows.
+ *
+ * Deliberately does NOT mirror the payload under a generic `item`/`items` key:
+ * `structuredContent` is billed to the agent's context window, and duplicating
+ * a full object to satisfy a shape convention would regress the token budget
+ * this issue is meant to protect.
+ */
+export function withEnvelope<T extends object>(
+	schema: string,
+	mode: string,
+	data: T
+): T & { schema: string; mode: string } {
+	return { schema, mode, ...data };
 }
 
 export function getPrimaryTextContent(response: McpResponse): string {

--- a/src/mcp/utils/metrics.ts
+++ b/src/mcp/utils/metrics.ts
@@ -142,9 +142,20 @@ export interface WriteHandlerSnapshot {
 }
 
 /** Serializable snapshot of everything the registry currently tracks. */
+export type ToolOutcome = "success" | "error" | "partial" | "degraded";
+
+export interface ToolOutcomeCounts {
+	success: number;
+	error: number;
+	partial: number;
+	degraded: number;
+}
+
 export interface MetricsSnapshot {
 	/** Per-tool dispatch latency, keyed by tool name. */
 	tools: Record<string, DurationStats>;
+	/** Outcome counts keyed by tool name; error-shaped responses are never counted as success. */
+	toolOutcomes: Record<string, ToolOutcomeCounts>;
 	/** Write-handler duration (store.withWrite fast path — no file lock held) — aggregate + per tool. */
 	writeHandler: WriteHandlerSnapshot;
 	/** Embedding batch latency (embedding-queue/worker.ts). */
@@ -153,6 +164,7 @@ export interface MetricsSnapshot {
 
 export class MetricsRegistry {
 	private readonly tools = new Map<string, DurationSeries>();
+	private readonly toolOutcomes = new Map<string, ToolOutcomeCounts>();
 	private readonly writeHandlerTotal = new DurationSeries();
 	private readonly writeHandlerByTool = new Map<string, DurationSeries>();
 	private readonly embedLatency = new DurationSeries();
@@ -166,9 +178,12 @@ export class MetricsRegistry {
 		return series;
 	}
 
-	/** Record a completed tool dispatch (success or error), ms elapsed. */
-	recordTool(toolName: string, ms: number): void {
+	/** Record a completed tool dispatch, its latency, and classified outcome. */
+	recordTool(toolName: string, ms: number, outcome: ToolOutcome = "success"): void {
 		this.seriesFor(this.tools, toolName).add(ms);
+		const counts = this.toolOutcomes.get(toolName) ?? { success: 0, error: 0, partial: 0, degraded: 0 };
+		counts[outcome]++;
+		this.toolOutcomes.set(toolName, counts);
 	}
 
 	/**
@@ -199,8 +214,12 @@ export class MetricsRegistry {
 		for (const [tool, series] of this.tools) {
 			tools[tool] = series.snapshot();
 		}
+		const toolOutcomes = Object.fromEntries(
+			[...this.toolOutcomes].map(([tool, counts]) => [tool, { ...counts }])
+		) as Record<string, ToolOutcomeCounts>;
 		return {
 			tools,
+			toolOutcomes,
 			writeHandler: {
 				total: this.writeHandlerTotal.snapshot(),
 				byTool: writeHandlerByTool
@@ -213,6 +232,7 @@ export class MetricsRegistry {
 	reset(): void {
 		for (const series of this.tools.values()) series.reset();
 		this.tools.clear();
+		this.toolOutcomes.clear();
 		for (const series of this.writeHandlerByTool.values()) series.reset();
 		this.writeHandlerByTool.clear();
 		this.writeHandlerTotal.reset();

--- a/src/mcp/utils/reuse-telemetry.ts
+++ b/src/mcp/utils/reuse-telemetry.ts
@@ -1,0 +1,273 @@
+import { createHash } from "node:crypto";
+import type { SQLiteStore } from "../storage/sqlite";
+import type { AgentContextSource } from "../tools/agent-context-compiler";
+import { logger } from "./logger";
+
+const ENABLED = process.env.ENABLE_REUSE_TELEMETRY !== "false";
+const RETENTION_DAYS = Math.max(1, Number.parseInt(process.env.REUSE_TELEMETRY_RETENTION_DAYS ?? "30", 10) || 30);
+const MAX_ROWS = Math.max(24, Number.parseInt(process.env.REUSE_TELEMETRY_MAX_ROWS ?? "20000", 10) || 20_000);
+const FLUSH_EVENTS = 4_096;
+const SESSION_CAP = 64;
+const SESSION_POINTER_CAP = 64;
+const SESSION_CLAIM_CAP = 16;
+const PACK_CACHE_CAP = 8;
+const PACK_CACHE_TTL_MS = 5 * 60_000;
+
+interface PendingDelta {
+	owner: string;
+	repo: string;
+	bucket: string;
+	metric: string;
+	source: string;
+	count: number;
+	value: number;
+}
+
+interface SessionState {
+	reads: Set<string>;
+	retrievedMemories: Set<string>;
+	claimedAt: Map<string, number>;
+	lastSeenAt: number;
+}
+
+function hash(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 24);
+}
+
+function hourBucket(now: Date): string {
+	const bucket = new Date(now);
+	bucket.setUTCMinutes(0, 0, 0);
+	return bucket.toISOString();
+}
+
+function sessionKey(sessionCorrelation: string | undefined, owner: string, repo: string): string {
+	return hash(sessionCorrelation || `${owner}/${repo}/anonymous`);
+}
+
+function latencyBucket(ms: number): string {
+	if (ms <= 100) return "le_100ms";
+	if (ms <= 500) return "le_500ms";
+	if (ms <= 1_000) return "le_1s";
+	if (ms <= 5_000) return "le_5s";
+	if (ms <= 30_000) return "le_30s";
+	return "gt_30s";
+}
+
+export class ReuseTelemetry {
+	private pending = new Map<string, PendingDelta>();
+	private sessions = new Map<string, SessionState>();
+	private packCache = new Map<string, { expiresAt: number; value: unknown }>();
+	private eventCount = 0;
+	private lastFlushAt = 0;
+	private lastPruneAt = 0;
+
+	constructor(private readonly enabled = ENABLED) {}
+
+	isEnabled(): boolean {
+		return this.enabled;
+	}
+
+	private state(sessionId: string): SessionState {
+		let state = this.sessions.get(sessionId);
+		if (!state) {
+			if (this.sessions.size >= SESSION_CAP) {
+				const oldest = [...this.sessions].sort((a, b) => a[1].lastSeenAt - b[1].lastSeenAt)[0]?.[0];
+				if (oldest) this.sessions.delete(oldest);
+			}
+			state = {
+				reads: new Set(),
+				retrievedMemories: new Set(),
+				claimedAt: new Map(),
+				lastSeenAt: Date.now()
+			};
+			this.sessions.set(sessionId, state);
+		}
+		state.lastSeenAt = Date.now();
+		return state;
+	}
+
+	private add(owner: string, repo: string, metric: string, value = 0, source = "", count = 1): void {
+		if (!this.enabled) return;
+		const bucket = hourBucket(new Date());
+		const key = `${owner}\u001f${repo}\u001f${bucket}\u001f${metric}\u001f${source}`;
+		const current = this.pending.get(key) ?? { owner, repo, bucket, metric, source, count: 0, value: 0 };
+		current.count += count;
+		current.value += value;
+		this.pending.set(key, current);
+	}
+
+	private markEvent(): void {
+		this.eventCount++;
+	}
+
+	createContextPackId(owner: string, repo: string, correlation: string): string {
+		return hash(`${owner}\u001f${repo}\u001f${correlation}`);
+	}
+
+	getCachedPack<T>(packId: string): T | undefined {
+		if (!this.enabled) return undefined;
+		const cached = this.packCache.get(packId);
+		if (!cached) return undefined;
+		if (cached.expiresAt <= Date.now()) {
+			this.packCache.delete(packId);
+			return undefined;
+		}
+		return cached.value as T;
+	}
+
+	cachePack(packId: string, value: unknown): void {
+		if (!this.enabled) return;
+		if (this.packCache.size >= PACK_CACHE_CAP) this.packCache.delete(this.packCache.keys().next().value!);
+		this.packCache.set(packId, { expiresAt: Date.now() + PACK_CACHE_TTL_MS, value });
+	}
+
+	recordContextPack(input: {
+		owner: string;
+		repo: string;
+		session?: string;
+		packId: string;
+		cacheLookup: boolean;
+		cacheHit: boolean;
+		allocation: Record<AgentContextSource, { included: number; excluded: number; estimated_tokens: number }>;
+		observationIds: string[];
+		memoryIds?: string[];
+		evidencePointers: number;
+		staleRejected: number;
+	}): void {
+		if (!this.enabled) return;
+		this.markEvent();
+		const state = this.state(sessionKey(input.session, input.owner, input.repo));
+		this.add(input.owner, input.repo, "context_packs_requested");
+		if (input.cacheLookup) {
+			this.add(input.owner, input.repo, input.cacheHit ? "context_cache_hits" : "context_cache_misses");
+		}
+		for (const [source, values] of Object.entries(input.allocation)) {
+			this.add(input.owner, input.repo, "context_items_included", 0, source, values.included);
+			this.add(input.owner, input.repo, "context_items_excluded", 0, source, values.excluded);
+			this.add(input.owner, input.repo, "context_estimated_tokens", values.estimated_tokens, source);
+		}
+		for (const id of input.memoryIds ?? []) {
+			if (state.retrievedMemories.size >= SESSION_POINTER_CAP) {
+				state.retrievedMemories.delete(state.retrievedMemories.values().next().value!);
+			}
+			state.retrievedMemories.add(hash(id));
+		}
+		this.add(input.owner, input.repo, "observation_ids_reused", 0, "", input.observationIds.length);
+		this.add(input.owner, input.repo, "evidence_pointers_reused", 0, "", input.evidencePointers);
+		this.add(input.owner, input.repo, "stale_observations_rejected", 0, "", input.staleRejected);
+		this.add(input.owner, input.repo, "observation_tokens_avoided", input.evidencePointers * 96);
+	}
+
+	recordTool(input: {
+		owner: string;
+		repo: string;
+		session?: string;
+		toolName: string;
+		args: Record<string, unknown>;
+		result: unknown;
+	}): void {
+		if (!this.enabled) return;
+		const relevant = ["codebase-read", "memory-read", "memory-write", "claim-manage", "task-write"].includes(
+			input.toolName
+		);
+		if (!relevant) return;
+		this.markEvent();
+		const state = this.state(sessionKey(input.session, input.owner, input.repo));
+		if (input.toolName === "codebase-read") {
+			const kind = input.args.filePath ? "file" : input.args.name ? "symbol" : null;
+			if (kind) {
+				const pointer = hash(`${kind}:${String(input.args.filePath ?? input.args.name)}:${input.repo}`);
+				const repeated = state.reads.has(pointer);
+				if (!repeated && state.reads.size >= SESSION_POINTER_CAP)
+					state.reads.delete(state.reads.values().next().value!);
+				state.reads.add(pointer);
+				this.add(input.owner, input.repo, `${kind}_reads`);
+				if (repeated) this.add(input.owner, input.repo, `repeated_${kind}_reads`);
+			}
+		}
+		if (input.toolName === "memory-read") {
+			const structured = (input.result as { structuredContent?: Record<string, unknown> } | undefined)
+				?.structuredContent;
+			const ids = [
+				(structured?.memory as { id?: string } | undefined)?.id,
+				...(Array.isArray(structured?.memories)
+					? (structured.memories as Array<{ id?: string }>).map((memory) => memory.id)
+					: []),
+				...(Array.isArray(structured?.results)
+					? (structured.results as Array<{ id?: string }>).map((memory) => memory.id)
+					: [])
+			].filter((id): id is string => Boolean(id));
+			for (const id of ids) {
+				if (state.retrievedMemories.size >= SESSION_POINTER_CAP) {
+					state.retrievedMemories.delete(state.retrievedMemories.values().next().value!);
+				}
+				state.retrievedMemories.add(hash(id));
+			}
+		}
+		if (
+			input.toolName === "claim-manage" &&
+			(input.args.task_id || input.args.task_code) &&
+			input.args.agent &&
+			!input.args.release
+		) {
+			const task = String(input.args.task_id ?? input.args.task_code);
+			if (state.claimedAt.size >= SESSION_CLAIM_CAP) state.claimedAt.delete(state.claimedAt.keys().next().value!);
+			state.claimedAt.set(hash(task), Date.now());
+		}
+		if (input.toolName === "task-write") {
+			const task = input.args.id ?? input.args.code ?? input.args.task_code;
+			if (task) {
+				const claimedAt = state.claimedAt.get(hash(String(task)));
+				if (claimedAt) {
+					const elapsedMs = Date.now() - claimedAt;
+					this.add(input.owner, input.repo, "claim_to_first_action_ms", elapsedMs, latencyBucket(elapsedMs));
+					state.claimedAt.delete(hash(String(task)));
+				}
+			}
+		}
+		if (input.toolName === "memory-write" && input.args.acknowledge === "used") {
+			const structured = (input.result as { structuredContent?: Record<string, unknown> } | undefined)
+				?.structuredContent;
+			const id = String(structured?.id ?? input.args.id ?? "");
+			if (id && state.retrievedMemories.delete(hash(id))) {
+				this.add(input.owner, input.repo, "retrievals_acknowledged_used");
+			}
+		}
+	}
+
+	flush(store: SQLiteStore): void {
+		if (!this.enabled || this.pending.size === 0) return;
+		const deltas = [...this.pending.values()];
+		try {
+			store.reuseTelemetry.flush(deltas);
+			const now = Date.now();
+			if (now - this.lastPruneAt >= 3_600_000) {
+				store.reuseTelemetry.prune(RETENTION_DAYS, MAX_ROWS);
+				this.lastPruneAt = now;
+			}
+			this.pending.clear();
+			this.eventCount = 0;
+			this.lastFlushAt = Date.now();
+		} catch (error) {
+			logger.warn("[ReuseTelemetry] Aggregate flush failed; counters retained", { error: String(error) });
+		}
+	}
+
+	flushIfNeeded(store: SQLiteStore): void {
+		if (!this.enabled) return;
+		if (this.eventCount >= FLUSH_EVENTS || (this.pending.size > 0 && Date.now() - this.lastFlushAt >= 60_000)) {
+			this.flush(store);
+		}
+	}
+
+	reset(): void {
+		this.pending.clear();
+		this.sessions.clear();
+		this.packCache.clear();
+		this.eventCount = 0;
+		this.lastFlushAt = 0;
+		this.lastPruneAt = 0;
+	}
+}
+
+export const reuseTelemetry = new ReuseTelemetry();

--- a/src/mcp/utils/source-fingerprint.ts
+++ b/src/mcp/utils/source-fingerprint.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+
+export interface StructuralSymbolFingerprintInput {
+	name: string;
+	kind: string;
+	exported?: boolean | number;
+	default_export?: boolean | number;
+	signature?: string | null;
+	doc_comment?: string | null;
+	semantic_signature?: string | null;
+	source_fingerprint?: string | null;
+}
+
+export function fingerprintSymbol(symbol: StructuralSymbolFingerprintInput): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify([
+				symbol.name,
+				symbol.kind,
+				Boolean(symbol.exported),
+				Boolean(symbol.default_export),
+				symbol.signature ?? null,
+				symbol.doc_comment ?? null,
+				symbol.semantic_signature ?? null,
+				symbol.source_fingerprint ?? null
+			])
+		)
+		.digest("hex");
+}
+
+export function fingerprintSourceRange(content: string, startLine?: number | null, endLine?: number | null): string {
+	const lines = content.split(/\r?\n/);
+	const start = Math.max(0, (startLine ?? 1) - 1);
+	const end = Math.max(start + 1, endLine ?? startLine ?? 1);
+	return createHash("sha256").update(lines.slice(start, end).join("\n")).digest("hex");
+}

--- a/src/mcp/utils/tool-plumbing.ts
+++ b/src/mcp/utils/tool-plumbing.ts
@@ -31,7 +31,8 @@ export const WRITE_TOOLS: ReadonlySet<string> = new Set([
 	"standard-delete",
 	// Tasks
 	"task-write",
-	"task-delete"
+	"task-delete",
+	"observation-write"
 ]);
 
 /**


### PR DESCRIPTION
## Ringkasan

PR ini menutup rangkaian masalah kontrak tool dan shared-context sekaligus: **#98, #99, #94, #92, #93, #95, #96, dan #102**.

Sebelumnya server punya banyak data, tetapi kontraknya masih bisa menyebut error sebagai sukses, mode `json` tidak konsisten, temuan eksplorasi belum punya bukti terstruktur, freshness belum dapat diverifikasi, context pack belum punya budget deterministik, runtime selalu menyalakan mesin mahal, dan manfaat reuse belum bisa diukur. Singkatnya: mesinnya sudah besar, tetapi beberapa indikator dashboard masih sekadar lampu dekorasi.

PR ini membuat setiap lapisan tersebut eksplisit, terukur, kompatibel, dan dibatasi.

## Perubahan

### 1. Kontrak error MCP yang benar — #98

- Semua handled failure memakai `isError: true` dan envelope stabil `schema: "tool-error"`.
- Menambahkan kode error, `retryable`, detail terstruktur, dan alias `error` sementara untuk kompatibilitas.
- Exception tak dikenal disanitasi; detail internal tetap hanya di server log.
- Partial bulk operation dibedakan dari kegagalan total.
- Outcome metrics membedakan `success`, `error`, `partial`, dan `degraded`.

### 2. Kontrak text/structured yang konsisten — #99

- `json:false` selalu menghasilkan ringkasan teks non-kosong tanpa payload terstruktur.
- `json:true` mempertahankan teks ringkas dan menambahkan `structuredContent`.
- Envelope memiliki discriminator `schema` dan `mode` stabil tanpa menggandakan payload.
- Consumer dashboard sekarang meminta JSON secara eksplisit.
- Field legacy tetap dipertahankan agar integrasi lama tidak pecah.

### 3. Observation dengan evidence first-class — #94

- Menambahkan `observation-write` dan `observation-read`.
- Migration v30 membuat observation yang ter-scope owner/repo dan evidence pointer ternormalisasi.
- Bulk write atomik sampai 100 item, dedup SHA-256 stabil, update eksplisit, dan filter terstruktur.
- Read tetap compact secara default; evidence hanya di-hydrate bila diminta.
- Tidak menyimpan raw source di observation.

### 4. Freshness berbasis fingerprint — #92

- Migration v31 menambahkan source/symbol fingerprint serta lifecycle `valid`, `stale`, `unverifiable`, dan supersession.
- Fingerprint dihitung dari exact source range + identitas struktural symbol.
- Reindex hanya merevalidasi observation yang terkait file berubah.
- Rename ditransfer, deletion ditandai, dan symbol yang tidak diketahui tidak pernah ditebak sebagai valid.
- Refresh eksplisit dibatasi dan tidak memanggil LLM.

### 5. Agent context sebagai compiler berbatas token — #93

- `agent-context` kini mengompilasi memory, decision, task, handoff, standard, observation, dan code pointer.
- Ranking deterministik berbasis nilai per token, dengan task/decision kritis diprioritaskan.
- Budget token/item/depth benar-benar ditegakkan; exclusion dan allocation dilaporkan.
- Code context hanya pointer/signature, bukan raw file dump.
- Output legacy `memories`, `decisions`, dan `tasks` tetap tersedia.
- Benchmark warm in-memory memenuhi p95 <250 ms.

### 6. Runtime capability profiles — #95

- Menambahkan profil `minimal`, `balanced`, dan `full`; default tetap `full` untuk kompatibilitas.
- Registry capability single-flight memiliki state `unavailable|idle|loading|ready|degraded|failed`.
- Semantic model, parser, watcher, maintenance, dan dashboard dapat diaktifkan sesuai profil.
- `codebase-index` mengekspos status runtime dan warmup eksplisit.
- Legacy env gates tetap dihormati.

Benchmark startup bundled, median 3 run:

| Profile | Initialize | RSS init | RSS +4s |
|---|---:|---:|---:|
| minimal | 503 ms | 196 MB | 184 MB |
| balanced | 472 ms | 200 MB | 190 MB |
| full | 1,095 ms | 405 MB | 225 MB |

### 7. Telemetry reuse yang privacy-safe — #96

- Migration v32 menyimpan aggregate per owner/repo/hour, bukan raw event atau prompt.
- Session, pointer, dan pack correlation disimpan sebagai hash pendek.
- Mengukur context packs, allocation/token per source, cache hit/miss nyata, reuse observation/evidence, stale rejection, repeated file/symbol reads, claim→first-action, dan retrieval→acknowledge.
- Retention 30 hari dan cap 20.000 row dapat dikonfigurasi; `ENABLE_REUSE_TELEMETRY=false` memberi jalur no-op murah.
- Metrics endpoint menyediakan ringkasan scoped dan north-star reuse ratio.
- Benchmark deterministik memakai SQLite nyata tanpa LLM.

Hasil benchmark reuse:

| Metrik | Baseline | Shared context | Dihemat |
|---|---:|---:|---:|
| File reads | 48 | 12 | 36 |
| Symbol reads | 96 | 24 | 72 |
| Estimated tokens | 13.824 | 5.760 | 8.064 |

Overhead telemetry: **0,158% CPU**, **94.152 byte heap**, DB total **720.896 byte**, pertumbuhan DB saat pengukuran **0 byte** (2 aggregate rows).

### 8. Identitas knowledge graph per repository — #102

- Migration v33 mengubah PK entity menjadi `(name, repo)` dan PK relation menjadi `(from_entity, to_entity, relation_type, repo)`.
- Historical entity di-backfill ke setiap repo yang dibuktikan oleh entity, observation, atau relation lama.
- Relation dan observation memakai composite foreign key yang repo-scoped.
- `entity_names_fts`, index KG, `kg_degrees`, serta seluruh trigger sinkronisasi dibangun ulang.
- Read, delete, retention, dashboard API, dan UI sekarang memperlakukan repo sebagai bagian wajib dari identitas.
- Migrasi berjalan dalam satu transaksi; kegagalan copy/FK mengembalikan schema lama. Rollback setelah sukses memakai backup pra-v33 karena collapse duplicate scoped names bersifat lossy.

Uji pada salinan DB 536 MB: **41,2 detik**, 1.287.971 relation dan 44.467 observation tetap utuh, entity menjadi 51.329 row, 4.032 nama collision kini punya row per-repo, `integrity_check=ok`, 0 pelanggaran FK, dan FTS berisi 51.329 row. Database asli tidak disentuh.

## Kompatibilitas dan privasi

- Default runtime tetap `full`.
- Existing tool names dan legacy response fields dipertahankan.
- Tidak ada prompt, source body, path privat, atau identifier proyek privat dalam telemetry maupun PR.
- Semua cache, candidate set, retention, dan persistence diberi batas eksplisit.
- Branch sudah direbase ke `main` terbaru dan mengikuti pemecahan modul upstream tanpa menghidupkan kembali monolit lama.

## Verifikasi setelah rebase terbaru

- `npm run type-check` — 0 TypeScript error; Svelte 0 error/0 warning
- `npm run lint` — pass untuk seluruh repository
- `npm run test -- --reporter=dot` — **257 files / 2.635 tests pass**
- `git diff --check` — pass
- privacy scan source, commit message, dan maintainer-visible PR diff — 0 identifier privat

## Catatan teknis yang agak pedas

Tujuh issue ini bukan tujuh fitur acak; semuanya adalah satu rantai sebab-akibat. Error yang menyamar sebagai sukses merusak orkestrasi. Structured payload tanpa kontrak merusak consumer. Observation tanpa evidence menjadi opini. Evidence tanpa freshness menjadi fosil. Context tanpa budget menjadi penyedot token. Runtime tanpa lazy loading membayar semua mesin sebelum dipakai. Dan tanpa telemetry, klaim “reuse” cuma perasaan yang kebetulan punya dashboard.

Sekarang rantainya punya kontrak, bukti, freshness, budget, lifecycle, dan angka. Server tidak lagi meminta maintainer percaya pada niat baik kode; server membawa kuitansinya sendiri.

Closes #98
Closes #99
Closes #94
Closes #92
Closes #93
Closes #95
Closes #96
Closes #102
