### PR TITLE
refactor(dashboard): split the three files this PR pushed over 500 lines

### DIFF
--- a/src/dashboard/ui/src/components/CodebaseExploreView.svelte
+++ b/src/dashboard/ui/src/components/CodebaseExploreView.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	/**
+	 * Explore mode: find one thing and read it.
+	 *
+	 * Owns nothing — every piece of state is passed in and every action is a
+	 * callback, so this stays a presentation shell. The parent keeps the
+	 * selection because Insights can also drive it (clicking a dead-code entry
+	 * or a graph node switches back here with a target already chosen).
+	 */
+	import Icon from "../lib/Icon.svelte";
+	import type { CodeSymbol } from "../lib/api";
+	import CodebaseSearchBar from "./CodebaseSearchBar.svelte";
+	import CodebaseSymbolDetail from "./CodebaseSymbolDetail.svelte";
+	import CodebaseFileViewer from "./CodebaseFileViewer.svelte";
+	import CodebaseSymbolList from "./CodebaseSymbolList.svelte";
+
+	let {
+		repo,
+		selectedSymbol,
+		selectedFile,
+		fileSymbols,
+		fileSymbolsLoading,
+		fileSymbolsError,
+		onSymbolSelect,
+		onOpenFile
+	}: {
+		repo: string;
+		selectedSymbol: CodeSymbol | null;
+		selectedFile: string | null;
+		fileSymbols: CodeSymbol[];
+		fileSymbolsLoading: boolean;
+		fileSymbolsError: string;
+		onSymbolSelect: (symbol: CodeSymbol) => void;
+		onOpenFile: (path: string) => void;
+	} = $props();
+</script>
+
+<section class="explore-view" aria-label="Explore codebase">
+	<CodebaseSearchBar {repo} {onSymbolSelect} />
+	<div class="explore-result">
+		{#if selectedSymbol}
+			<CodebaseSymbolDetail
+				symbol={selectedSymbol}
+				references={[]}
+				loading={false}
+				{repo}
+				{onSymbolSelect}
+				{onOpenFile}
+			/>
+		{:else if selectedFile}
+			<CodebaseFileViewer {repo} filePath={selectedFile} />
+			<CodebaseSymbolList symbols={fileSymbols} loading={fileSymbolsLoading} {onSymbolSelect} />
+			{#if fileSymbolsError}<div class="inline-error">{fileSymbolsError}</div>{/if}
+		{:else}
+			<div class="explore-empty">
+				<Icon name="file-text" size={28} /><strong>Choose a file or search for a symbol</strong><span
+					>The file tree keeps your place while results open here.</span
+				>
+			</div>
+		{/if}
+	</div>
+</section>
+
+<style>
+	/* Moved verbatim from CodebasePage so the split is presentation-neutral. */
+	.explore-view {
+		display: grid;
+		gap: 20px;
+	}
+	.explore-result {
+		min-height: 360px;
+		padding: 20px;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
+		background: var(--color-surface);
+	}
+	.explore-empty {
+		display: grid;
+		place-items: center;
+		align-content: center;
+		gap: 8px;
+		min-height: 320px;
+		color: var(--color-text-muted);
+		text-align: center;
+	}
+	.explore-empty strong {
+		color: var(--color-text);
+	}
+	.inline-error {
+		margin-top: 12px;
+		padding: 12px;
+		border-radius: var(--radius-md);
+		background: rgba(239, 68, 68, 0.1);
+		color: var(--color-danger);
+		font-size: 0.8rem;
+	}
+</style>

--- a/src/dashboard/ui/src/components/CodebaseInsightsView.svelte
+++ b/src/dashboard/ui/src/components/CodebaseInsightsView.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	/**
+	 * Insights mode: architecture, exports, dead code, and the symbol graph.
+	 *
+	 * Both of its navigation actions hand control back to Explore, so the mode
+	 * switch is the parent's decision — this component only reports what was
+	 * picked.
+	 */
+	import type { CodeSymbol, DeadCodeBlock } from "../lib/api";
+	import CodebaseIndexStatus from "./CodebaseIndexStatus.svelte";
+	import CodebaseLanguageBreakdown from "./CodebaseLanguageBreakdown.svelte";
+	import CodebaseTopExports from "./CodebaseTopExports.svelte";
+	import CodebaseDeadCode from "./CodebaseDeadCode.svelte";
+	import CodebaseGraphPanel from "./CodebaseGraphPanel.svelte";
+
+	interface LanguageEntry {
+		name: string;
+		count: number;
+		percentage: number;
+		color: string;
+	}
+
+	interface TopExport {
+		name: string;
+		kind: string;
+		file_path: string;
+	}
+
+	let {
+		repo,
+		languageEntries,
+		indexKindCounts,
+		topLevelExports,
+		deadCodeBlock,
+		onOpenFile,
+		onSymbolSelect
+	}: {
+		repo: string;
+		languageEntries: LanguageEntry[];
+		indexKindCounts: Record<string, number>;
+		topLevelExports: TopExport[];
+		deadCodeBlock: DeadCodeBlock | null;
+		onOpenFile: (path: string) => void;
+		onSymbolSelect: (symbol: CodeSymbol) => void;
+	} = $props();
+</script>
+
+<section class="insights-view" aria-label="Codebase insights">
+	<CodebaseIndexStatus {repo} languageCount={languageEntries.length} kindCounts={indexKindCounts} />
+	<div class="insight-grid">
+		<CodebaseLanguageBreakdown {languageEntries} /><CodebaseTopExports {topLevelExports} />
+	</div>
+	<CodebaseDeadCode block={deadCodeBlock} {onOpenFile} />
+	<CodebaseGraphPanel {repo} {onSymbolSelect} />
+</section>
+
+<style>
+	/* Moved verbatim from CodebasePage so the split is presentation-neutral. */
+	.insights-view {
+		display: grid;
+		gap: 20px;
+	}
+	.insight-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 20px;
+	}
+</style>

--- a/src/dashboard/ui/src/components/CodebasePage.svelte
+++ b/src/dashboard/ui/src/components/CodebasePage.svelte
@@ -2,17 +2,11 @@
 	import Icon from "../lib/Icon.svelte";
 	import { api, type CodeSymbol, type DeadCodeBlock } from "../lib/api";
 	import { currentRepo } from "../lib/stores";
-	import CodebaseSymbolDetail from "./CodebaseSymbolDetail.svelte";
-	import CodebaseIndexStatus from "./CodebaseIndexStatus.svelte";
-	import CodebaseSearchBar from "./CodebaseSearchBar.svelte";
 	import CodebaseFileTree from "./CodebaseFileTree.svelte";
-	import CodebaseSymbolList from "./CodebaseSymbolList.svelte";
+	import CodebaseViewTabs from "./CodebaseViewTabs.svelte";
+	import CodebaseExploreView from "./CodebaseExploreView.svelte";
+	import CodebaseInsightsView from "./CodebaseInsightsView.svelte";
 	import CodebaseEmptyState from "./CodebaseEmptyState.svelte";
-	import CodebaseLanguageBreakdown from "./CodebaseLanguageBreakdown.svelte";
-	import CodebaseDeadCode from "./CodebaseDeadCode.svelte";
-	import CodebaseFileViewer from "./CodebaseFileViewer.svelte";
-	import CodebaseGraphPanel from "./CodebaseGraphPanel.svelte";
-	import CodebaseTopExports from "./CodebaseTopExports.svelte";
 	import { aggregateSymbolCounts } from "../lib/fileTreeUtils";
 
 	let { repo = "" }: { repo: string } = $props();
@@ -263,72 +257,35 @@
 						</div>
 						<div class="repo-badge">{$currentRepo}</div>
 					</header>
-					<div class="view-tabs" role="tablist" aria-label="Codebase views">
-						<button
-							role="tab"
-							aria-selected={activeView === "explore"}
-							class:active={activeView === "explore"}
-							onclick={() => (activeView = "explore")}><Icon name="search" size={16} /> Explore</button
-						>
-						<button
-							role="tab"
-							aria-selected={activeView === "insights"}
-							class:active={activeView === "insights"}
-							onclick={() => (activeView = "insights")}><Icon name="activity" size={16} /> Insights</button
-						>
-					</div>
+					<CodebaseViewTabs {activeView} onSelect={(view) => (activeView = view)} />
 
 					{#if activeView === "explore"}
-						<section class="explore-view" aria-label="Explore codebase">
-							<CodebaseSearchBar {repo} onSymbolSelect={handleSymbolSelect} />
-							<div class="explore-result">
-								{#if selectedSymbol}
-									<CodebaseSymbolDetail
-										symbol={selectedSymbol}
-										references={[]}
-										loading={false}
-										{repo}
-										onSymbolSelect={handleSymbolSelect}
-										onOpenFile={openCodebaseFile}
-									/>
-								{:else if selectedFile}
-									<CodebaseFileViewer {repo} filePath={selectedFile} />
-									<CodebaseSymbolList
-										symbols={fileSymbols}
-										loading={fileSymbolsLoading}
-										onSymbolSelect={handleSymbolSelect}
-									/>
-									{#if fileSymbolsError}<div class="inline-error">{fileSymbolsError}</div>{/if}
-								{:else}
-									<div class="explore-empty">
-										<Icon name="file-text" size={28} /><strong>Choose a file or search for a symbol</strong><span
-											>The file tree keeps your place while results open here.</span
-										>
-									</div>
-								{/if}
-							</div>
-						</section>
+						<CodebaseExploreView
+							{repo}
+							{selectedSymbol}
+							{selectedFile}
+							{fileSymbols}
+							{fileSymbolsLoading}
+							{fileSymbolsError}
+							onSymbolSelect={handleSymbolSelect}
+							onOpenFile={openCodebaseFile}
+						/>
 					{:else}
-						<section class="insights-view" aria-label="Codebase insights">
-							<CodebaseIndexStatus {repo} languageCount={languageEntries.length} kindCounts={indexKindCounts} />
-							<div class="insight-grid">
-								<CodebaseLanguageBreakdown {languageEntries} /><CodebaseTopExports {topLevelExports} />
-							</div>
-							<CodebaseDeadCode
-								block={deadCodeBlock}
-								onOpenFile={(path) => {
-									openCodebaseFile(path);
-									activeView = "explore";
-								}}
-							/>
-							<CodebaseGraphPanel
-								{repo}
-								onSymbolSelect={(symbol) => {
-									handleSymbolSelect(symbol);
-									activeView = "explore";
-								}}
-							/>
-						</section>
+						<CodebaseInsightsView
+							{repo}
+							{languageEntries}
+							{indexKindCounts}
+							{topLevelExports}
+							{deadCodeBlock}
+							onOpenFile={(path) => {
+								openCodebaseFile(path);
+								activeView = "explore";
+							}}
+							onSymbolSelect={(symbol) => {
+								handleSymbolSelect(symbol);
+								activeView = "explore";
+							}}
+						/>
 					{/if}
 				</div>
 			</main>
@@ -469,72 +426,7 @@
 		text-transform: uppercase;
 		color: var(--color-primary);
 	}
-	.view-tabs {
-		display: inline-flex;
-		width: fit-content;
-		padding: 4px;
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-md);
-		background: var(--color-surface);
-	}
-	.view-tabs button {
-		display: inline-flex;
-		align-items: center;
-		gap: 8px;
-		min-height: 40px;
-		padding: 0 16px;
-		border: 0;
-		border-radius: calc(var(--radius-md) - 3px);
-		background: transparent;
-		color: var(--color-text-muted);
-		font-weight: 700;
-		cursor: pointer;
-	}
-	.view-tabs button.active {
-		background: var(--color-primary);
-		color: #fff;
-	}
 	@media (pointer: coarse) {
-		.view-tabs button {
-			min-height: 44px;
-		}
-	}
-	.explore-view,
-	.insights-view {
-		display: grid;
-		gap: 20px;
-	}
-	.explore-result {
-		min-height: 360px;
-		padding: 20px;
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-lg);
-		background: var(--color-surface);
-	}
-	.explore-empty {
-		display: grid;
-		place-items: center;
-		align-content: center;
-		gap: 8px;
-		min-height: 320px;
-		color: var(--color-text-muted);
-		text-align: center;
-	}
-	.explore-empty strong {
-		color: var(--color-text);
-	}
-	.inline-error {
-		margin-top: 12px;
-		padding: 12px;
-		border-radius: var(--radius-md);
-		background: rgba(239, 68, 68, 0.1);
-		color: var(--color-danger);
-		font-size: 0.8rem;
-	}
-	.insight-grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 20px;
 	}
 
 	/* ── Repo badge (reuse pattern) ── */

--- a/src/dashboard/ui/src/components/CodebaseViewTabs.svelte
+++ b/src/dashboard/ui/src/components/CodebaseViewTabs.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	/**
+	 * Explore/Insights mode switch.
+	 *
+	 * Split out with the two views it toggles so the tab markup, its styles and
+	 * its touch-target rule live next to each other instead of in the page
+	 * shell.
+	 */
+	import Icon from "../lib/Icon.svelte";
+
+	let {
+		activeView,
+		onSelect
+	}: {
+		activeView: "explore" | "insights";
+		onSelect: (view: "explore" | "insights") => void;
+	} = $props();
+</script>
+
+<div class="view-tabs" role="tablist" aria-label="Codebase views">
+	<button
+		role="tab"
+		aria-selected={activeView === "explore"}
+		class:active={activeView === "explore"}
+		onclick={() => onSelect("explore")}><Icon name="search" size={16} /> Explore</button
+	>
+	<button
+		role="tab"
+		aria-selected={activeView === "insights"}
+		class:active={activeView === "insights"}
+		onclick={() => onSelect("insights")}><Icon name="activity" size={16} /> Insights</button
+	>
+</div>
+
+<style>
+	/* Moved verbatim from CodebasePage so the split is presentation-neutral. */
+	.view-tabs {
+		display: inline-flex;
+		width: fit-content;
+		padding: 4px;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+	}
+	.view-tabs button {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		min-height: 40px;
+		padding: 0 16px;
+		border: 0;
+		border-radius: calc(var(--radius-md) - 3px);
+		background: transparent;
+		color: var(--color-text-muted);
+		font-weight: 700;
+		cursor: pointer;
+	}
+	.view-tabs button.active {
+		background: var(--color-primary);
+		color: #fff;
+	}
+	@media (pointer: coarse) {
+		.view-tabs button {
+			min-height: 44px;
+		}
+	}
+</style>

--- a/src/dashboard/ui/src/components/MemoryCards.svelte
+++ b/src/dashboard/ui/src/components/MemoryCards.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+	/**
+	 * Memory cards — the narrow-viewport presentation of the rows the table
+	 * shows on desktop.
+	 *
+	 * Split out of MemoryList for the same reason as the queue cards: one file
+	 * should not carry two full presentations of the same data. Visibility stays
+	 * media-query driven (hidden above 720px), so the parent renders both and
+	 * CSS picks one — no resize listener, no hydration mismatch.
+	 *
+	 * `.type-chip` is intentionally NOT redeclared here: it is a global rule, so
+	 * copying it would create the duplicate-selector problem this split exists
+	 * to remove.
+	 */
+	import type { Memory } from "../lib/stores";
+	import { formatDate } from "../lib/utils";
+	import { TYPE_LABELS, importanceColor } from "../lib/memoryConfig";
+
+	let {
+		memories = [],
+		loading = false,
+		hasError = false,
+		selectedIds,
+		onToggleSelect,
+		onMemoryClick
+	}: {
+		memories: Memory[];
+		loading: boolean;
+		hasError: boolean;
+		selectedIds: Set<string>;
+		onToggleSelect: (id: string) => void;
+		onMemoryClick: (mem: Memory) => void;
+	} = $props();
+</script>
+
+<div class="memory-cards" aria-label="Memories">
+	{#if loading}
+		{#each { length: 4 } as _, i (i)}
+			<div class="memory-card skeleton" style="height:112px;"></div>
+		{/each}
+	{:else if !hasError}
+		{#each memories as mem (mem.id)}
+			<article class="memory-card" class:selected={selectedIds.has(mem.id)}>
+				<div class="memory-card-topline">
+					<input
+						type="checkbox"
+						checked={selectedIds.has(mem.id)}
+						onchange={() => onToggleSelect(mem.id)}
+						aria-label="Select memory {mem.title}"
+					/>
+					<span class="type-chip type-{mem.type}">{TYPE_LABELS[mem.type] || mem.type}</span>
+					<span class="memory-card-importance" style="color:{importanceColor[mem.importance] || importanceColor[1]};">
+						Importance {mem.importance}
+					</span>
+				</div>
+				<button class="memory-card-main" onclick={() => onMemoryClick(mem)}>
+					<strong>{mem.title || "Untitled memory"}</strong>
+					<span>{formatDate(mem.updated_at)} · {mem.hit_count ?? 0} hits</span>
+				</button>
+				{#if mem.tags?.length}
+					<div class="memory-card-tags">
+						{#each mem.tags.slice(0, 3) as tag (tag)}<span>{tag}</span>{/each}
+					</div>
+				{/if}
+			</article>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	/* Moved verbatim from MemoryList so the split is presentation-neutral. */
+	.memory-cards {
+		display: none;
+	}
+
+	@media (max-width: 720px) {
+		.memory-cards {
+			display: grid;
+			gap: 10px;
+		}
+
+		.memory-card {
+			padding: 14px;
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius-md);
+			background: var(--color-surface);
+		}
+
+		.memory-card.selected {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+		}
+
+		.memory-card-topline {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+		}
+
+		.memory-card-importance {
+			margin-left: auto;
+			font-size: 0.6875rem;
+			font-weight: 700;
+		}
+
+		.memory-card-main {
+			display: grid;
+			gap: 4px;
+			width: 100%;
+			min-height: 48px;
+			margin-top: 10px;
+			padding: 0;
+			border: 0;
+			background: transparent;
+			text-align: left;
+			color: var(--color-text);
+			cursor: pointer;
+		}
+
+		.memory-card-main strong {
+			font-size: 0.9375rem;
+			line-height: 1.35;
+		}
+
+		.memory-card-main span {
+			font-size: 0.75rem;
+			color: var(--color-text-muted);
+		}
+
+		.memory-card-tags {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 4px;
+			margin-top: 8px;
+		}
+
+		.memory-card-tags span {
+			padding: 2px 6px;
+			border-radius: 999px;
+			background: var(--color-surface-hover);
+			font-size: 0.6875rem;
+			color: var(--color-text-muted);
+		}
+	}
+</style>

--- a/src/dashboard/ui/src/components/MemoryList.svelte
+++ b/src/dashboard/ui/src/components/MemoryList.svelte
@@ -15,6 +15,7 @@
 	import type { Memory } from "../lib/stores";
 	import Icon from "../lib/Icon.svelte";
 	import { TYPE_LABELS, importanceColor, importanceBg } from "../lib/memoryConfig";
+	import MemoryCards from "./MemoryCards.svelte";
 	import MemoryListToolbar from "./MemoryListToolbar.svelte";
 	import MemoryListPagination from "./MemoryListPagination.svelte";
 	import MemoryBulkActions from "./MemoryBulkActions.svelte";
@@ -216,42 +217,14 @@
 			</tbody>
 		</table>
 
-		<div class="memory-cards" aria-label="Memories">
-			{#if memoryHandler.loading}
-				{#each { length: 4 } as _, i (i)}
-					<div class="memory-card skeleton" style="height:112px;"></div>
-				{/each}
-			{:else if !memoryHandler.error}
-				{#each $memories as mem (mem.id)}
-					<article class="memory-card" class:selected={$selectedMemoryIds.has(mem.id)}>
-						<div class="memory-card-topline">
-							<input
-								type="checkbox"
-								checked={$selectedMemoryIds.has(mem.id)}
-								onchange={() => memoryHandler.toggleSelect(mem.id)}
-								aria-label="Select memory {mem.title}"
-							/>
-							<span class="type-chip type-{mem.type}">{TYPE_LABELS[mem.type] || mem.type}</span>
-							<span
-								class="memory-card-importance"
-								style="color:{importanceColor[mem.importance] || importanceColor[1]};"
-							>
-								Importance {mem.importance}
-							</span>
-						</div>
-						<button class="memory-card-main" onclick={() => onMemoryClick(mem)}>
-							<strong>{mem.title || "Untitled memory"}</strong>
-							<span>{formatDate(mem.updated_at)} · {mem.hit_count ?? 0} hits</span>
-						</button>
-						{#if mem.tags?.length}
-							<div class="memory-card-tags">
-								{#each mem.tags.slice(0, 3) as tag (tag)}<span>{tag}</span>{/each}
-							</div>
-						{/if}
-					</article>
-				{/each}
-			{/if}
-		</div>
+		<MemoryCards
+			memories={$memories}
+			loading={memoryHandler.loading}
+			hasError={!!memoryHandler.error}
+			selectedIds={$selectedMemoryIds}
+			onToggleSelect={(id) => memoryHandler.toggleSelect(id)}
+			{onMemoryClick}
+		/>
 	</div>
 
 	<MemoryListPagination
@@ -292,10 +265,6 @@
 		width: 100%;
 		border-collapse: collapse;
 		min-width: 680px;
-	}
-
-	.memory-cards {
-		display: none;
 	}
 
 	/* ── Head ── */
@@ -432,74 +401,6 @@
 			overflow: visible;
 			border: 0;
 			background: transparent;
-		}
-
-		.memory-cards {
-			display: grid;
-			gap: 10px;
-		}
-
-		.memory-card {
-			padding: 14px;
-			border: 1px solid var(--color-border);
-			border-radius: var(--radius-md);
-			background: var(--color-surface);
-		}
-
-		.memory-card.selected {
-			border-color: var(--color-primary);
-			box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
-		}
-
-		.memory-card-topline {
-			display: flex;
-			align-items: center;
-			gap: 8px;
-		}
-
-		.memory-card-importance {
-			margin-left: auto;
-			font-size: 0.6875rem;
-			font-weight: 700;
-		}
-
-		.memory-card-main {
-			display: grid;
-			gap: 4px;
-			width: 100%;
-			min-height: 48px;
-			margin-top: 10px;
-			padding: 0;
-			border: 0;
-			background: transparent;
-			text-align: left;
-			color: var(--color-text);
-			cursor: pointer;
-		}
-
-		.memory-card-main strong {
-			font-size: 0.9375rem;
-			line-height: 1.35;
-		}
-
-		.memory-card-main span {
-			font-size: 0.75rem;
-			color: var(--color-text-muted);
-		}
-
-		.memory-card-tags {
-			display: flex;
-			flex-wrap: wrap;
-			gap: 4px;
-			margin-top: 8px;
-		}
-
-		.memory-card-tags span {
-			padding: 2px 6px;
-			border-radius: 999px;
-			background: var(--color-surface-hover);
-			font-size: 0.6875rem;
-			color: var(--color-text-muted);
 		}
 	}
 </style>

--- a/src/dashboard/ui/src/components/QueueJobCards.svelte
+++ b/src/dashboard/ui/src/components/QueueJobCards.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+	/**
+	 * Failed-job cards — the narrow-viewport presentation of the same rows the
+	 * table shows on desktop.
+	 *
+	 * Split out of QueueJobsTable so the table markup and the card markup stop
+	 * competing for one file. Visibility stays media-query driven (hidden above
+	 * 720px) rather than JS-gated, so there is no resize listener and no
+	 * hydration mismatch; the parent renders both and CSS picks one.
+	 *
+	 * Purely presentational: every mutation is a callback, matching the
+	 * table's contract.
+	 */
+	import Icon from "../lib/Icon.svelte";
+	import type { QueueJob } from "../lib/api";
+	import { formatDate } from "../lib/utils";
+
+	let {
+		jobs = [],
+		loading = false,
+		busy = null,
+		statusLabel,
+		onRetry = null,
+		onClear = null
+	}: {
+		jobs: QueueJob[];
+		loading: boolean;
+		busy: { id: string; action: "retry" | "clear" } | null;
+		statusLabel: (s: QueueJob["status"]) => string;
+		onRetry: ((job: QueueJob) => void) | null;
+		onClear: ((job: QueueJob) => void) | null;
+	} = $props();
+</script>
+
+<div class="job-cards" aria-label="Failed queue jobs">
+	{#if loading}
+		{#each { length: 3 } as _, i (i)}
+			<div class="job-card"><div class="skeleton" style="height:140px;border-radius:10px;"></div></div>
+		{/each}
+	{:else if jobs.length === 0}
+		<div class="job-empty">
+			<Icon name="circle-check" size={24} /><strong>No failed jobs</strong><span
+				>The queue is healthy. Failed jobs will appear here.</span
+			>
+		</div>
+	{:else}
+		{#each jobs as job (job.id)}
+			<article class="job-card">
+				<div class="job-heading">
+					<div class="entity-cell">
+						<span class="entity-kind">{job.entity_kind}</span><strong>{job.entity_id}</strong>
+					</div>
+					<span class="status-pill status-failed">{statusLabel(job.status)}</span>
+				</div>
+				<dl>
+					<div>
+						<dt>Attempts</dt>
+						<dd>{job.attempts} / {job.max_attempts}</dd>
+					</div>
+					<div>
+						<dt>Enqueued</dt>
+						<dd>{formatDate(job.enqueued_at)}</dd>
+					</div>
+				</dl>
+				{#if job.last_error}<p class="job-error">{job.last_error}</p>{/if}
+				<div class="mobile-actions">
+					<button class="btn btn-ghost" onclick={() => onRetry?.(job)} disabled={busy?.id === job.id}>Re-run</button
+					><button class="btn btn-danger" onclick={() => onClear?.(job)} disabled={busy?.id === job.id}>Clear</button>
+				</div>
+			</article>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	/* Moved verbatim from QueueJobsTable so the split is presentation-neutral.
+	   The card list is desktop-hidden; the table takes over above 720px. */
+	.job-cards {
+		display: none;
+	}
+
+	.entity-cell {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.entity-kind {
+		font-size: 0.68rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--color-primary);
+	}
+
+	.status-pill {
+		border-radius: 999px;
+		padding: 2px 8px;
+		font-size: 0.67rem;
+		text-transform: uppercase;
+		font-weight: 850;
+		border: 1px solid var(--color-border);
+		display: inline-block;
+	}
+
+	.status-failed {
+		color: #b91c1c;
+		background: rgba(239, 68, 68, 0.12);
+	}
+
+	:global(html.dark) .status-failed {
+		color: #fca5a5;
+	}
+
+	@media (max-width: 720px) {
+		.job-cards {
+			display: grid;
+			gap: 12px;
+		}
+		.job-card {
+			display: grid;
+			gap: 14px;
+			padding: 16px;
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius-lg);
+			background: var(--color-surface);
+		}
+		.job-heading {
+			display: flex;
+			align-items: flex-start;
+			justify-content: space-between;
+			gap: 12px;
+		}
+		.job-heading strong {
+			max-width: 190px;
+			overflow-wrap: anywhere;
+			font-size: 0.85rem;
+		}
+		.job-card dl {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 12px;
+			margin: 0;
+		}
+		.job-card dl div {
+			display: grid;
+			gap: 4px;
+		}
+		.job-card dt {
+			font-size: 0.68rem;
+			font-weight: 700;
+			color: var(--color-text-muted);
+			text-transform: uppercase;
+		}
+		.job-card dd {
+			margin: 0;
+			font-size: 0.8rem;
+		}
+		.job-error {
+			margin: 0;
+			padding: 12px;
+			border-radius: var(--radius-md);
+			background: rgba(239, 68, 68, 0.1);
+			color: var(--color-danger);
+			font-size: 0.78rem;
+			overflow-wrap: anywhere;
+		}
+		.mobile-actions {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			gap: 8px;
+		}
+		.job-empty {
+			display: grid;
+			justify-items: center;
+			gap: 8px;
+			padding: 36px 16px;
+			color: var(--color-text-muted);
+			text-align: center;
+		}
+		.job-empty strong {
+			color: var(--color-text);
+		}
+	}
+</style>

--- a/src/dashboard/ui/src/components/QueueJobsTable.svelte
+++ b/src/dashboard/ui/src/components/QueueJobsTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from "../lib/Icon.svelte";
 	import type { QueueJob } from "../lib/api";
+	import QueueJobCards from "./QueueJobCards.svelte";
 	import { formatDate } from "../lib/utils";
 
 	/**
@@ -174,45 +175,7 @@
 		</table>
 	</div>
 
-	<div class="job-cards" aria-label="Failed queue jobs">
-		{#if loading}
-			{#each { length: 3 } as _, i (i)}
-				<div class="job-card"><div class="skeleton" style="height:140px;border-radius:10px;"></div></div>
-			{/each}
-		{:else if jobs.length === 0}
-			<div class="job-empty">
-				<Icon name="circle-check" size={24} /><strong>No failed jobs</strong><span
-					>The queue is healthy. Failed jobs will appear here.</span
-				>
-			</div>
-		{:else}
-			{#each jobs as job (job.id)}
-				<article class="job-card">
-					<div class="job-heading">
-						<div class="entity-cell">
-							<span class="entity-kind">{job.entity_kind}</span><strong>{job.entity_id}</strong>
-						</div>
-						<span class="status-pill status-failed">{statusLabel(job.status)}</span>
-					</div>
-					<dl>
-						<div>
-							<dt>Attempts</dt>
-							<dd>{job.attempts} / {job.max_attempts}</dd>
-						</div>
-						<div>
-							<dt>Enqueued</dt>
-							<dd>{formatDate(job.enqueued_at)}</dd>
-						</div>
-					</dl>
-					{#if job.last_error}<p class="job-error">{job.last_error}</p>{/if}
-					<div class="mobile-actions">
-						<button class="btn btn-ghost" onclick={() => onRetry?.(job)} disabled={busy?.id === job.id}>Re-run</button
-						><button class="btn btn-danger" onclick={() => onClear?.(job)} disabled={busy?.id === job.id}>Clear</button>
-					</div>
-				</article>
-			{/each}
-		{/if}
-	</div>
+	<QueueJobCards {jobs} {loading} {busy} {statusLabel} {onRetry} {onClear} />
 
 	{#if totalPages > 1}
 		<div class="pagination">
@@ -461,10 +424,6 @@
 		color: var(--color-text-muted);
 	}
 
-	.job-cards {
-		display: none;
-	}
-
 	@media (max-width: 720px) {
 		.queue-section {
 			padding: 16px;
@@ -482,74 +441,6 @@
 		}
 		.mem-table-wrap {
 			display: none;
-		}
-		.job-cards {
-			display: grid;
-			gap: 12px;
-		}
-		.job-card {
-			display: grid;
-			gap: 14px;
-			padding: 16px;
-			border: 1px solid var(--color-border);
-			border-radius: var(--radius-lg);
-			background: var(--color-surface);
-		}
-		.job-heading {
-			display: flex;
-			align-items: flex-start;
-			justify-content: space-between;
-			gap: 12px;
-		}
-		.job-heading strong {
-			max-width: 190px;
-			overflow-wrap: anywhere;
-			font-size: 0.85rem;
-		}
-		.job-card dl {
-			display: grid;
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-			gap: 12px;
-			margin: 0;
-		}
-		.job-card dl div {
-			display: grid;
-			gap: 4px;
-		}
-		.job-card dt {
-			font-size: 0.68rem;
-			font-weight: 700;
-			color: var(--color-text-muted);
-			text-transform: uppercase;
-		}
-		.job-card dd {
-			margin: 0;
-			font-size: 0.8rem;
-		}
-		.job-error {
-			margin: 0;
-			padding: 12px;
-			border-radius: var(--radius-md);
-			background: rgba(239, 68, 68, 0.1);
-			color: var(--color-danger);
-			font-size: 0.78rem;
-			overflow-wrap: anywhere;
-		}
-		.mobile-actions {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			gap: 8px;
-		}
-		.job-empty {
-			display: grid;
-			justify-items: center;
-			gap: 8px;
-			padding: 36px 16px;
-			color: var(--color-text-muted);
-			text-align: center;
-		}
-		.job-empty strong {
-			color: var(--color-text);
 		}
 		.pagination {
 			justify-content: space-between;


### PR DESCRIPTION
Review is right, and the blame is entirely on this PR. All three files were UNDER the limit on main and this branch is what pushed them over:

  CodebasePage.svelte    453 -> 568
  QueueJobsTable.svelte  430 -> 564
  MemoryList.svelte      377 -> 505

The pattern was the same each time: a mobile card list bolted onto a file that already owned a desktop table, or two view modes stuffed into one page shell. Two full presentations of the same data in one file.

Extracted along the seam that already existed:

  CodebaseExploreView    search + file/symbol result
  CodebaseInsightsView   index status, exports, dead code, graph
  CodebaseViewTabs       the Explore/Insights switch, with its own styles
  QueueJobCards          the <=720px card list
  MemoryCards            the <=720px card list

  CodebasePage    460   QueueJobsTable  455   MemoryList  407

MemoryList was not flagged in review, but it is the same violation introduced by the same commit, so it is fixed here rather than left for a follow-up.

The split is presentation-neutral: every moved rule is copied verbatim, including the media queries the cards depend on, and the card components keep their own `display: none` default so visibility stays CSS-driven — no resize listener, no JS gating, no hydration mismatch. `.type-chip` is deliberately NOT copied into MemoryCards; it is a global rule, and duplicating it would recreate the problem this split removes.

Verified: 0 files over 500 lines anywhere in the dashboard UI, full suite 258 files / 2646 tests, typecheck 0 errors, svelte-check 0 warnings, eslint clean. Browser: Explore/Insights switch both ways with aria-selected tracking, memory + queue cards render at 390px with the desktop tables hidden, 0 sub-44px targets and 0 overflow.